### PR TITLE
Fixed RollingFileAppender for JRuby 1.6.1

### DIFF
--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -182,7 +182,7 @@ module Logging::Appenders
     def canonical_write( str )
       return self if @io.nil?
 
-      @io.flock_sh { @io.syswrite(str) }
+      @io.flock_ex { @io.syswrite(str) }
 
       if roll_required?
         @io.flock? {

--- a/lib/logging/utils.rb
+++ b/lib/logging/utils.rb
@@ -164,6 +164,17 @@ class File
     flock LOCK_UN
   end
 
+  # Execute the <tt>block</tt> in the context of an exclusive lock on this file. A
+  # shared lock will be obtained on the file, the block executed, and the lock
+  # released.
+  #
+  def flock_ex( &block )
+    flock LOCK_EX
+    block.call
+  ensure
+    flock LOCK_UN
+  end
+
   # :stopdoc:
   if %r/mswin|mingw/ =~ RUBY_PLATFORM
     undef :flock?, :flock_sh


### PR DESCRIPTION
Hey Tim,

we had problems using the RollingFileAppender with the latest JRuby 1.6.1 again. I fixed that by resorting to an exclusive flock for the files. Wrote a method just beside the SH_LOCK -using.

I don't really know about further implications, and I was unable to come up with relevant research on that matter. But in fact, it now works for us again. Maybe you could have a look and include or reject my changes?

Thanks in advance and cheers,
Seb
