### PR TITLE
File locking fails on Windows when using JRuby

### DIFF
--- a/lib/logging/utils.rb
+++ b/lib/logging/utils.rb
@@ -1,5 +1,6 @@
 
 require 'thread'
+require 'rbconfig'
 
 # --------------------------------------------------------------------------
 class Hash
@@ -165,7 +166,9 @@ class File
   end
 
   # :stopdoc:
-  if %r/mswin|mingw/ =~ RUBY_PLATFORM
+  include Config
+  if CONFIG['host_os'] =~ /mswin|windows|cygwin/i # JRuby will always set RUBY_PLATFORM=java
+    # don't lock files on windows
     undef :flock?, :flock_sh
     def flock?() yield; end
     def flock_sh() yield; end


### PR DESCRIPTION
RUBY_PLATFORM will always be 'java' for JRuby on any platform
