### PR TITLE
Fix 1.9.3-p125's deprecation of Config::* deprecation warning

### DIFF
--- a/lib/logging/utils.rb
+++ b/lib/logging/utils.rb
@@ -1,4 +1,3 @@
-
 require 'thread'
 require 'rbconfig'
 
@@ -166,7 +165,8 @@ class File
   end
 
   # :stopdoc:
-  if Config::CONFIG['host_os'] =~ /mswin|windows|cygwin/i
+  CONF = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
+  if CONF['host_os'] =~ /mswin|windows|cygwin/i
     # don't lock files on windows
     undef :flock?, :flock_sh
     def flock?() yield; end


### PR DESCRIPTION
Looks like 1.9.3-p125 deprecates Config::\* use and spits this deprecation out:
/usr/lib/ruby/gems/1.9.1/gems/logging-1.7.0/lib/logging/utils.rb:169: Use RbConfig instead of obsolete and deprecated Config.

This fixes it and should be backwards compatible. Just a minimal change.
