### PR TITLE
Fix clash with ActiveSupport autoloader.

### DIFF
--- a/lib/logging/color_scheme.rb
+++ b/lib/logging/color_scheme.rb
@@ -203,9 +203,8 @@ module Logging
     # Return a normalized representation of a color setting.
     #
     def to_constant( v )
-      ColorScheme.const_get(v.to_s.upcase)
-    rescue NameError
-      return  nil
+      v = v.to_s.upcase
+      ColorScheme.const_get(v) if ColorScheme.const_defined?(v)
     end
 
     # Embed in a String to clear all previous ANSI sequences.  This *MUST* be


### PR DESCRIPTION
For example, passing :message to ColorScheme#color should not cause message.rb to be loaded, and it certainly shouldn't bail when it finds Message instead of MESSAGE.

This was initially reported in adhearsion/adhearsion#182.
