### PR TITLE
Filtering mechanism similar to log4j or slf4j filters

### DIFF
--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -528,6 +528,7 @@ module Logging
 
   require libpath('logging/appender')
   require libpath('logging/layout')
+  require libpath('logging/filter')
   require libpath('logging/log_event')
   require libpath('logging/logger')
   require libpath('logging/repository')
@@ -536,6 +537,7 @@ module Logging
   require libpath('logging/color_scheme')
   require libpath('logging/appenders')
   require libpath('logging/layouts')
+  require libpath('logging/filters')
   require libpath('logging/proxy')
   require libpath('logging/diagnostic_context')
 

--- a/lib/logging/filter.rb
+++ b/lib/logging/filter.rb
@@ -1,0 +1,21 @@
+module Logging
+
+  # The +Filter+ class allows for filtering messages based on event
+  # properties independently of the standard minimum-level restriction.
+  #
+  # All other Filters inherit from this class, and must override the
+  # +allow+ method to return true if the event should be allowed into
+  # the log, and false otherwise.
+  #
+  class Filter
+
+    # call-seq:
+    #    allow( event )
+    #
+    # Returns true if the given _event_ should be allowed to proceed
+    # to the log, and false if it should be prevented.
+    def allow( event )
+      true
+    end
+  end
+end

--- a/lib/logging/filters.rb
+++ b/lib/logging/filters.rb
@@ -1,0 +1,4 @@
+module Logging
+  module Filters ; end
+  require libpath('logging/filters/level')
+end

--- a/lib/logging/filters/level.rb
+++ b/lib/logging/filters/level.rb
@@ -1,0 +1,28 @@
+require 'set'
+
+module Logging
+  module Filters
+
+    # The +Level+ filter class provides a simple level-based filtering mechanism
+    # that filters messages to only include those from an enumerated list of
+    # levels to log.
+    class Level < ::Logging::Filter
+
+      # call-seq:
+      #    Level.new ( *levels )
+      #
+      # Creates a new level filter that will only allow the given _levels_ to
+      # propagate through to the logger.  The _levels_ should be given in symbolic
+      # form.
+      def initialize(*levels)
+        super()
+        @levels = Set.new(levels.map { |level| ::Logging::level_num(level) })
+      end
+
+      def allow(event)
+        @levels.include?(event.level)
+      end
+
+    end
+  end
+end

--- a/test/test_appender.rb
+++ b/test/test_appender.rb
@@ -40,6 +40,30 @@ module TestLogging
       assert_raise(RuntimeError) {@appender.append @event}
     end
 
+    def test_append_with_filter
+      ary = []
+      @appender.instance_variable_set :@ary, ary
+      def @appender.write(event)
+        @ary << event
+      end
+      @appender.level = :debug
+
+      # Excluded
+      @appender.filter = ::Logging::Filters::Level.new :info
+      @appender.append @event
+      assert_nil ary.pop
+
+      # Allowed
+      @appender.filter = ::Logging::Filters::Level.new :debug
+      @appender.append @event
+      assert_equal @event, ary.pop
+
+      # No filter
+      @appender.filter = nil
+      @appender.append @event
+      assert_equal @event, ary.pop
+    end
+
     def test_close
       assert_equal false, @appender.closed?
 

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -1,0 +1,31 @@
+require File.expand_path('setup', File.dirname(__FILE__))
+
+module TestLogging
+
+  class TestFilter < Test::Unit::TestCase
+    include LoggingTestCase
+
+    def setup
+      ::Logging::init
+      @lf = ::Logging::Filters::Level.new :debug, :warn
+    end
+
+    def test_level_filter_includes_selected_level
+      debug_evt = event_for_level(:debug)
+      warn_evt = event_for_level(:warn)
+      assert @lf.allow(debug_evt), "Debug messages should be allowed"
+      assert @lf.allow(warn_evt), "Warn messages should be allowed"
+    end
+
+    def test_level_filter_excludes_unselected_level
+      event = event_for_level(:info)
+      assert !@lf.allow(event), "Info messages should be disallowed"
+    end
+
+    def event_for_level(level)
+      ::Logging::LogEvent.new('logger', ::Logging::LEVELS[level.to_s],
+                              'message', false)
+    end
+
+  end
+end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -406,6 +406,34 @@ module TestLogging
       assert_equal true,  logb.info?
     end
 
+    def test_level_with_filter
+      root = ::Logging::Logger[:root]
+      root.level = 'debug'
+
+      details_filter = ::Logging::Filters::Level.new :debug
+      error_filter = ::Logging::Filters::Level.new :error
+
+      a_detail = ::Logging::Appenders::StringIo.new 'detail', :filter => details_filter
+      a_error = ::Logging::Appenders::StringIo.new 'error', :filter => error_filter
+
+      root.add_appenders a_detail, a_error
+
+      log = ::Logging::Logger.new 'A Logger'
+
+      log.debug "debug level"
+      assert_equal "DEBUG  A Logger : debug level\n", a_detail.readline
+      assert_nil a_error.readline
+
+      log.error "error level"
+      assert_nil a_detail.readline
+      assert_equal "ERROR  A Logger : error level\n", a_error.readline
+
+      log.warn "warn level"
+      assert_nil a_detail.readline
+      assert_nil a_error.readline
+
+    end
+
     def test_log
       root = ::Logging::Logger[:root]
       root.level = 'info'


### PR DESCRIPTION
Logging::Filter provides a base class for implementing arbitrary
event-based filtering of log events.

Logging::Filter::Level implements this to limit log messages to an
appender to only those that match a specific, enumerated list of log
levels.