### PR TITLE
"write" methods (#add, #info, #debug, etc.) are inconsistent with Ruby Logger (and Log4r), and trigger nasty ripple effects

### DIFF
--- a/lib/logging/logger.rb
+++ b/lib/logging/logger.rb
@@ -103,7 +103,7 @@ module Logging
           if logger.level > num
             code << <<-CODE
               def #{name}?( ) false end
-              def #{name}( data = nil ) false end
+              def #{name}( data = nil ) true end
             CODE
           else
             code << <<-CODE

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -452,30 +452,40 @@ module TestLogging
       assert_nil a1.readline
       assert_nil a2.readline
 
-      assert_equal false, log.debug
+      assert_equal true, log.debug
+      assert_equal false, log.debug?
       assert_equal true, log.info
+      assert_equal true, log.info?
       assert_equal " INFO  A Logger : <NilClass> nil\n", a1.readline
       assert_equal " INFO  A Logger : <NilClass> nil\n", a2.readline
       assert_equal true, log.warn
+      assert_equal true, log.warn?
       assert_equal " WARN  A Logger : <NilClass> nil\n", a1.readline
       assert_equal " WARN  A Logger : <NilClass> nil\n", a2.readline
       assert_equal true, log.error
+      assert_equal true, log.error?
       assert_equal "ERROR  A Logger : <NilClass> nil\n", a1.readline
       assert_equal "ERROR  A Logger : <NilClass> nil\n", a2.readline
       assert_equal true, log.fatal
+      assert_equal true, log.fatal?
       assert_equal "FATAL  A Logger : <NilClass> nil\n", a1.readline
       assert_equal "FATAL  A Logger : <NilClass> nil\n", a2.readline
 
       log.level = :warn
-      assert_equal false, log.debug
-      assert_equal false, log.info
+      assert_equal true, log.debug
+      assert_equal false, log.debug?
+      assert_equal true, log.info
+      assert_equal false, log.info?
       assert_equal true, log.warn
+      assert_equal true, log.warn?
       assert_equal " WARN  A Logger : <NilClass> nil\n", a1.readline
       assert_equal " WARN  A Logger : <NilClass> nil\n", a2.readline
       assert_equal true, log.error
+      assert_equal true, log.error?
       assert_equal "ERROR  A Logger : <NilClass> nil\n", a1.readline
       assert_equal "ERROR  A Logger : <NilClass> nil\n", a2.readline
       assert_equal true, log.fatal
+      assert_equal true, log.fatal?
       assert_equal "FATAL  A Logger : <NilClass> nil\n", a1.readline
       assert_equal "FATAL  A Logger : <NilClass> nil\n", a2.readline
 


### PR DESCRIPTION
I've just started porting an existing app from `log4r` to `logging`. 

An issue I discovered very quickly was that `logging` was breaking a fair number of my Rails model callbacks. Model callbacks require a non-false result in order to complete successfully.  The result was that I had debug logging methods which record the end of a callbacks execution that where effectively disabling the callback chain.

I checked other logging tools to see what they chose to use:
* Rails Logger always returns `true`
* Log4r always returns `nil`Here is a pull request which resolves Issue #71


I picked the Rails Logger implementation as the more approach (also means only 1 changed line vs 2).

Note: This pull request applies cleanly to both master(3ce0721) and two-point-oh(5c06041)