### PR TITLE
Be more explicit about which symbol we use as a gatekeeper so that other...

### DIFF
--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -1,7 +1,7 @@
 
 # Equivalent to a header guard in C/C++
 # Used to prevent the class/module from being loaded more than once
-unless defined? Logging
+unless defined? ::Logging::RailsCompat
 
 require File.expand_path('../logging/utils', __FILE__)
 


### PR DESCRIPTION
... gems can use 'Logging' module namespace also.