### PR TITLE
explicitly state that color_scheme.rb is MIT license

### DIFF
--- a/lib/logging/color_scheme.rb
+++ b/lib/logging/color_scheme.rb
@@ -4,7 +4,9 @@
 # Created by Jeremy Hinegardner on 2007-01-24
 # Copyright 2007.  All rights reserved
 #
-# This is Free Software.  See LICENSE and COPYING for details
+# This file is licensed under the terms of the MIT License.
+# See the README for licensing details.
+#
 
 module Logging
 


### PR DESCRIPTION
As the original author of `color_scheme.rb` I am explicitly stating that it is under the terms of the MIT license to keep it under the same license as the logging gem.