### PR TITLE
Refactor the pattern layout builder

### DIFF
--- a/lib/logging/layouts/pattern.rb
+++ b/lib/logging/layouts/pattern.rb
@@ -382,10 +382,10 @@ module Logging::Layouts
 
           case directive
           when '%'; format_string << '%%'
-          when 'c'; handle_logger_name( format, directive, precision )
-          when 'l'; handle_level(       format, directive, precision )
-          when 'X'; handle_mdc(         format, directive, precision )
-          when 'x'; handle_ndc(         format, directive, precision )
+          when 'c'; handle_logger( format, directive, precision )
+          when 'l'; handle_level(  format, directive, precision )
+          when 'X'; handle_mdc(    format, directive, precision )
+          when 'x'; handle_ndc(    format, directive, precision )
 
           when *DIRECTIVE_TABLE.keys
             handle_directives(format, directive, precision)
@@ -404,7 +404,7 @@ module Logging::Layouts
 
       #
       #
-      def handle_logger_name( format, directive, precision )
+      def handle_logger( format, directive, precision )
         fmt = format + 's'
         fmt = color_scheme.color(fmt, COLOR_ALIAS_TABLE[directive]) if color_scheme and !color_scheme.lines?
 


### PR DESCRIPTION
As has been pointed out already in #98, the code to build up the `format` method for the Pattern layout is very obtuse and hard to follow. The goal of this refactoring is to pull the massive `case` statement out into a builder class that is easier to reason about and easier to maintain.