### PR TITLE
Encodings!

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,6 @@ Bones {
   depend_on 'little-plugger', '~> 1.1'
   depend_on 'multi_json',     '~> 1.10'
 
-  depend_on 'flexmock',  '~> 1.0', :development => true
   depend_on 'bones-git', '~> 1.3', :development => true
   #depend_on 'bones-rcov',   :development => true
 }

--- a/test/appenders/test_buffered_io.rb
+++ b/test/appenders/test_buffered_io.rb
@@ -10,9 +10,12 @@ module TestAppenders
 
     def setup
       super
-      @appender = Logging.appenders.string_io(
-        'test_appender', :auto_flushing => 3, :immediate_at => :error
-      )
+      @appender = Logging.appenders.string_io \
+        'test_appender',
+        :auto_flushing => 3,
+        :immediate_at  => :error,
+        :encoding      => 'UTF-8'
+
       @appender.clear
       @sio = @appender.sio
       @levels = Logging::LEVELS

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -100,14 +100,13 @@ module TestAppenders
 
       def test_encoding
         log = File.join(TMP, 'file-encoding.log')
-        #appender = Logging.appenders.file(NAME, :filename => log, :encoding => 'ISO-8859-16')
         appender = Logging.appenders.file(NAME, :filename => log, :encoding => 'ASCII')
 
         appender << "A normal line of text\n"
         appender << "ümlaut\n"
         appender.close
 
-        lines = File.readlines(log)
+        lines = File.readlines(log, :encoding => 'UTF-8')
         assert_equal "A normal line of text\n", lines[0]
         assert_equal "ümlaut\n", lines[1]
 


### PR DESCRIPTION
Making the appender tests more resilient in the face of default encodings specified in the environment. Also cleaning up the Rakefile a bit.

closes #114 
closes #115 
