### PR TITLE
syslog, file, rolling_file appender factory methods: Fail explicitly on bad arguments

### DIFF
--- a/lib/logging/appenders/file.rb
+++ b/lib/logging/appenders/file.rb
@@ -4,7 +4,7 @@ module Logging::Appenders
   # Accessor / Factory for the File appender.
   #
   def self.file( *args )
-    return ::Logging::Appenders::File if args.empty?
+    fail ArgumentError, '::Logging::Appenders::File needs a name as first argument.' if args.empty?
     ::Logging::Appenders::File.new(*args)
   end
 

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -2,7 +2,7 @@ module Logging::Appenders
 
   # Accessor / Factory for the RollingFile appender.
   def self.rolling_file( *args )
-    return ::Logging::Appenders::RollingFile if args.empty?
+    fail ArgumentError, '::Logging::Appenders::RollingFile needs a name as first argument.' if args.empty?
     ::Logging::Appenders::RollingFile.new(*args)
   end
 

--- a/lib/logging/appenders/syslog.rb
+++ b/lib/logging/appenders/syslog.rb
@@ -9,7 +9,7 @@ module Logging::Appenders
   # Accessor / Factory for the Syslog appender.
   #
   def self.syslog( *args )
-    return ::Logging::Appenders::Syslog if args.empty?
+    fail ArgumentError, '::Logging::Appenders::Syslog needs a name as first argument.' if args.empty?
     ::Logging::Appenders::Syslog.new(*args)
   end
 

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -23,21 +23,21 @@ module TestAppenders
     def test_class_assert_valid_logfile
       log = File.join(TMP, 'uw_dir', 'file.log')
       assert_raise(ArgumentError) do
-        Logging.appenders.file.assert_valid_logfile(log)
+        Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
       log = File.join(TMP, 'dir')
       assert_raise(ArgumentError) do
-        Logging.appenders.file.assert_valid_logfile(log)
+        Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
       log = File.join(TMP, 'uw_file')
       assert_raise(ArgumentError) do
-        Logging.appenders.file.assert_valid_logfile(log)
+        Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
       log = File.join(TMP, 'file.log')
-      assert Logging.appenders.file.assert_valid_logfile(log)
+      assert Logging.appenders.file(log).class.assert_valid_logfile(log)
     end
 
     def test_initialize

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -20,6 +20,12 @@ module TestAppenders
       FileUtils.chmod 0444, File.join(TMP, 'uw_file')
     end
 
+    def test_factory_method_validates_input
+      assert_raise(ArgumentError) do
+        Logging.appenders.file
+      end
+    end
+
     def test_class_assert_valid_logfile
       log = File.join(TMP, 'uw_dir', 'file.log')
       assert_raise(ArgumentError) do

--- a/test/appenders/test_rolling_file.rb
+++ b/test/appenders/test_rolling_file.rb
@@ -18,6 +18,12 @@ module TestAppenders
       @glob = File.expand_path('*.log', TMP)
     end
 
+    def test_factory_method_validates_input
+      assert_raise(ArgumentError) do
+        Logging.appenders.rolling_file
+      end
+    end
+
     def test_initialize
       assert_equal [], Dir.glob(@glob)
 

--- a/test/appenders/test_syslog.rb
+++ b/test/appenders/test_syslog.rb
@@ -19,6 +19,12 @@ module TestAppenders
       @logopt |= ::Syslog::LOG_PERROR if defined?(::Syslog::LOG_PERROR)
     end
 
+    def test_factory_method_validates_input
+      assert_raise(ArgumentError) do
+        Logging.appenders.syslog
+      end
+    end
+
     def test_append
       return if RUBY_PLATFORM =~ %r/cygwin|java/i
 


### PR DESCRIPTION
In order to create a syslog appender, the user must supply a name. The factory method should reflect this issue with a validation.

The previous implementation returned a class, not an instance. This led to errors like this:

```
ArgumentError: unknown appender Logging::Appenders::Syslog
  add_appenders at /Users/olle/.rvm/gems/jruby-1.7.18/gems/logging-2.0.0/lib/logging/logger.rb:321
           each at org/jruby/RubyArray.java:1613
  add_appenders at /Users/olle/.rvm/gems/jruby-1.7.18/gems/logging-2.0.0/lib/logging/logger.rb:319
         (root) at o.rb:3
```

My test program was:

```ruby
require 'logging'
l = Logging::Logger['mongrel']
l.add_appenders( Logging.appenders.syslog )
l.level = :info

l.warn "HEJ!"
```

The test program will now raise an explicit error when the user has not supplied any arguments to the syslog factory.

Workaround: always supply a name as a string to the syslog factory.