### PR TITLE
allow whitespaces in traced method name

### DIFF
--- a/lib/logging/log_event.rb
+++ b/lib/logging/log_event.rb
@@ -11,7 +11,7 @@ module Logging
     # * $1 == filename
     # * $2 == line number
     # * $3 == method name (might be nil)
-    CALLER_RGXP = %r/([-\.\/\(\)\w]+):(\d+)(?::in `([\s\w]+)')?/o
+    CALLER_RGXP = %r/([-\.\/\(\)\w]+):(\d+)(?::in `([^']+)')?/o
     #CALLER_INDEX = 2
     CALLER_INDEX = ((defined? JRUBY_VERSION and JRUBY_VERSION > '1.6') or (defined? RUBY_ENGINE and RUBY_ENGINE[%r/^rbx/i])) ? 1 : 2
     # :startdoc:

--- a/lib/logging/log_event.rb
+++ b/lib/logging/log_event.rb
@@ -11,7 +11,7 @@ module Logging
     # * $1 == filename
     # * $2 == line number
     # * $3 == method name (might be nil)
-    CALLER_RGXP = %r/([-\.\/\(\)\w]+):(\d+)(?::in `(\w+)')?/o
+    CALLER_RGXP = %r/([-\.\/\(\)\w]+):(\d+)(?::in `([\s\w]+)')?/o
     #CALLER_INDEX = 2
     CALLER_INDEX = ((defined? JRUBY_VERSION and JRUBY_VERSION > '1.6') or (defined? RUBY_ENGINE and RUBY_ENGINE[%r/^rbx/i])) ? 1 : 2
     # :startdoc:


### PR DESCRIPTION
Sometimes I have traces like this one : ```/home/akarzim/project/app/models/foo.rb:147:in `rescue in foo'```

In order to get the method name, I have updated the CALLER_RGXP regular expression to allow whitespaces in method name.