### PR TITLE
Fixed the level= method to be thread safe.

### DIFF
--- a/lib/logging/logger.rb
+++ b/lib/logging/logger.rb
@@ -26,6 +26,10 @@ module Logging
 
     @mutex = Mutex.new  # :nodoc:
 
+    def instance_mutex # :nodoc:
+      @instance_mutex ||= Mutex.new
+    end
+
     class << self
 
       # Returns the root logger.
@@ -419,12 +423,14 @@ module Logging
     # call-seq:
     #    _meta_eval( code )
     #
-    # Evaluates the given string of _code_ if the singleton class of this
+    # Evaluates the given string of _code_ in the singleton class of this
     # Logger object.
     #
     def _meta_eval( code, file = nil, line = nil )
-      meta = class << self; self end
-      meta.class_eval code, file, line
+      instance_mutex.synchronize do
+        meta = class << self; self end
+        meta.class_eval code, file, line
+      end
     end
 
     # call-seq:
@@ -500,4 +506,3 @@ module Logging
 
   end  # Logger
 end  # Logging
-


### PR DESCRIPTION
The problem: the current code in `master` is very thread-unsafe. Rubies without a GIL can experience this; it's very easy to replicate this bug with the sample script provided below. Rubies _with_ a GIL (like MRI) don't have a problem with this since they're not really multi-threaded in the true sense of the word.

I've tested this fix with the following Ruby versions and it seems to work correctly on all of them:

- ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15] (worked correctly even before the fix)
- jruby 1.7.24 (1.9.3p551) 2016-01-20 bd68d85 on Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 [darwin-x86_64]
- jruby 9.0.5.0 (2.2.3) 2016-01-26 7bee00d Java HotSpot(TM) 64-Bit Server VM 24.80-b11 on 1.7.0_80-b15 [darwin-x86_64]

The following script has been used to demonstrate the problem:

```ruby
require 'logging'

logger = Logging.logger['foo']
(0..10).map {
  Thread.new { logger.level = :info }
}.each(&:join)
```