### PR TITLE
Make object id in #inspect match default behavior

### DIFF
--- a/lib/logging/appender.rb
+++ b/lib/logging/appender.rb
@@ -257,9 +257,9 @@ class Appender
   # Returns a string representation of the appender.
   #
   def inspect
-    "<%s:0x%x name=\"%s\">" % [
+    "<%s:0x%014x name=\"%s\">" % [
         self.class.name.sub(%r/^Logging::/, ''),
-        self.object_id,
+        (self.object_id << 1),
         self.name
     ]
   end

--- a/lib/logging/logger.rb
+++ b/lib/logging/logger.rb
@@ -366,7 +366,7 @@ module Logging
     # Returns a string representation of the logger.
     #
     def inspect
-      "<%s:0x%x name=\"%s\">" % [self.class.name, self.object_id, self.name]
+      "<%s:0x%014x name=\"%s\">" % [self.class.name, (self.object_id << 1), self.name]
     end
 
 

--- a/test/test_appender.rb
+++ b/test/test_appender.rb
@@ -190,10 +190,17 @@ module TestLogging
     end
 
     def test_inspect
-      expected = "<Appender:0x%x name=\"test_appender\">" % @appender.object_id
+      expected = "<Appender:0x%014x name=\"test_appender\">" % (@appender.object_id << 1)
       assert_equal expected, @appender.inspect
     end
 
+    def test_inspect_matches_default
+      # `to_s` triggers the default inspect behavior
+      expected = @appender.to_s.match(/0x[a-f\d]+/)[0]
+      actual = @appender.inspect.match(/0x[a-f\d]+/)[0]
+
+      assert_equal expected, actual
+    end
   end  # class TestAppender
 end  # module TestLogging
 

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -268,8 +268,18 @@ module TestLogging
     def test_inspect
       root = ::Logging::Logger.new :root
 
-      str = "<#{root.class.name}:0x%x name=\"#{root.name}\">" % root.object_id
+      str = "<#{root.class.name}:0x%014x name=\"#{root.name}\">" % (root.object_id << 1)
       assert_equal str, root.inspect
+    end
+
+    def test_inspect_matches_default
+      root = ::Logging::Logger.new :root
+
+      # `to_s` triggers the default inspect behavior
+      expected = root.to_s.match(/0x[a-f\d]+/)[0]
+      actual = root.inspect.match(/0x[a-f\d]+/)[0]
+
+      assert_equal expected, actual
     end
 
     def test_level


### PR DESCRIPTION
It's very confusing when `logger.to_s` or `"#{logger}"` show different
object ids than `logger.inspect`. This makes the custom `inspect`
implementation match Ruby's default formatting of object ids.