### PR TITLE
Enable asynchronous writes of the log buffer

### DIFF
--- a/lib/logging/appenders/buffering.rb
+++ b/lib/logging/appenders/buffering.rb
@@ -218,6 +218,12 @@ module Logging::Appenders
       _setup_async_flusher
     end
 
+    # Returns `true` if an asynchronous flush period has been defined for the
+    # appender.
+    def flush_period?
+      !@flush_period.nil?
+    end
+
     # Enable or disable asynchronous logging via a dedicated logging Thread.
     # Pass in `true` to enable and `false` to disable.
     #
@@ -290,7 +296,7 @@ module Logging::Appenders
           else
             self.flush
           end
-        elsif @async_flusher
+        elsif @async_flusher && flush_period?
           @async_flusher.signal
         end
       end

--- a/test/appenders/test_async_flushing.rb
+++ b/test/appenders/test_async_flushing.rb
@@ -160,6 +160,7 @@ module TestAppenders
       event.level = @levels['debug']
       event.data = 'the big log message'
       @appender.append event
+      sleep 0.250
       assert_nil(readline)
 
       event.level = @levels['info']

--- a/test/appenders/test_async_flushing.rb
+++ b/test/appenders/test_async_flushing.rb
@@ -4,14 +4,15 @@ require File.expand_path('../setup', File.dirname(__FILE__))
 module TestLogging
 module TestAppenders
 
-  class TestPeriodicFlushing < Test::Unit::TestCase
+  class TestAsyncFlushing < Test::Unit::TestCase
     include LoggingTestCase
 
     def setup
       super
-      @appender = Logging.appenders.string_io(
-        'test_appender', :flush_period => 2
-      )
+      @appender = Logging.appenders.string_io \
+        'test_appender',
+        :flush_period => 2
+
       @appender.clear
       @sio = @appender.sio
       @levels = Logging::LEVELS
@@ -129,13 +130,64 @@ module TestAppenders
       assert_nil(readline)
     end
 
+    def test_setting_flush_period_to_nil
+      flusher = @appender.instance_variable_get(:@async_flusher)
+      assert_instance_of Logging::Appenders::Buffering::AsyncFlusher, flusher
+
+      @appender.flush_period = nil
+
+      assert_nil @appender.instance_variable_get(:@async_flusher)
+    end
+
+    def test_setting_negative_flush_period
+      assert_raise(ArgumentError) { @appender.flush_period = -1 }
+    end
+
+    def test_async_writes
+      @appender.flush_period = nil
+      @appender.async = true
+      @appender.auto_flushing = 3
+
+      event = Logging::LogEvent.new('TestLogger', @levels['warn'],
+                                    [1, 2, 3, 4], false)
+
+      flusher = @appender.instance_variable_get(:@async_flusher)
+      assert_instance_of Logging::Appenders::Buffering::AsyncFlusher, flusher
+
+      @appender.append event
+      assert_nil(readline)
+
+      event.level = @levels['debug']
+      event.data = 'the big log message'
+      @appender.append event
+      assert_nil(readline)
+
+      event.level = @levels['info']
+      event.data = 'just FYI'
+      @appender.append event  # might write here, might not
+      sleep 0.250             # so sleep a little to let the write occur
+
+      assert_equal " WARN  TestLogger : <Array> #{[1, 2, 3, 4]}\n", readline
+      assert_equal "DEBUG  TestLogger : the big log message\n", readline
+      assert_equal " INFO  TestLogger : just FYI\n", readline
+
+      event.level = @levels['warn']
+      event.data = 'this is your last warning!'
+      @appender.append event
+      assert_nil(readline)
+
+      @appender.close_method = :close_write
+      @appender.close
+
+      assert_equal " WARN  TestLogger : this is your last warning!\n", readline
+
+      assert_nil @appender.instance_variable_get(:@async_flusher)
+    end
+
   private
     def readline
       @appender.readline
     end
-
-  end  # class TestPeriodicFlushing
-
-end  # module TestAppenders
-end  # module TestLogging
-
+  end
+end
+end

--- a/test/appenders/test_periodic_flushing.rb
+++ b/test/appenders/test_periodic_flushing.rb
@@ -42,12 +42,12 @@ module TestAppenders
       assert_equal 200, @appender.auto_flushing
     end
 
-    def test_periodic_flusher_running
-      flusher = @appender.instance_variable_get(:@periodic_flusher)
-      assert_instance_of Logging::Appenders::Buffering::PeriodicFlusher, flusher
+    def test_async_flusher_running
+      flusher = @appender.instance_variable_get(:@async_flusher)
+      assert_instance_of Logging::Appenders::Buffering::AsyncFlusher, flusher
 
       sleep 0.250  # give the flusher thread another moment to start
-      assert flusher.waiting?, 'the periodic flusher should be waiting for a signal'
+      assert flusher.waiting?, 'the async flusher should be waiting for a signal'
     end
 
     def test_append

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -74,7 +74,7 @@ module Logging
         puts "Log4r:      not supported" if log4r
       end
 
-      write_size         = 500
+      write_size         = 250
       auto_flushing_size = 500
 
       logging_async = ::Logging.logger['AsyncFile']

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -1,4 +1,3 @@
-
 require 'rubygems'
 
 libpath = File.expand_path('../../lib', __FILE__)
@@ -22,13 +21,11 @@ module Logging
     def run
       this_many = 300_000
 
-      Logging.appenders.string_io(
-        'sio',
-        :layout => Logging.layouts.pattern(
-          :pattern => '%.1l, [%d] %5l -- %c: %m\n',
-          :date_pattern => "%Y-%m-%dT%H:%M:%S.%s"
-        )
-      )
+      pattern = Logging.layouts.pattern \
+        :pattern      => '%.1l, [%d #%p] %5l -- %c: %m\n',
+        :date_pattern => "%Y-%m-%dT%H:%M:%S.%s"
+
+      Logging.appenders.string_io('sio', :layout => pattern)
       sio = Logging.appenders['sio'].sio
 
       logging = ::Logging.logger('benchmark')
@@ -39,16 +36,16 @@ module Logging
       logger.level = ::Logger::WARN
 
       log4r = if $log4r
-        x = ::Log4r::Logger.new('benchmark')
-        x.level = ::Log4r::WARN
-        x.add ::Log4r::IOOutputter.new(
+        l4r = ::Log4r::Logger.new('benchmark')
+        l4r.level = ::Log4r::WARN
+        l4r.add ::Log4r::IOOutputter.new(
           'benchmark', sio,
           :formatter => ::Log4r::PatternFormatter.new(
             :pattern => "%.1l, [%d #\#{Process.pid}] %5l : %M\n",
-            :date_pattern => "%Y-%m-%dT%H:%M:%S.\#{Time.now.usec}"
+            :date_pattern => "%Y-%m-%dT%H:%M:%S.%6N"
           )
         )
-        x
+        l4r
       end
 
       puts "== Debug (not logged) ==\n"
@@ -76,14 +73,41 @@ module Logging
         bm.report('Logger:') {this_many.times {logger << 'logged'}}
         puts "Log4r:      not supported" if log4r
       end
+
+      write_size         = 500
+      auto_flushing_size = 500
+
+      logging_async = ::Logging.logger['AsyncFile']
+      logging_async.level = :info
+      logging_async.appenders = Logging.appenders.file \
+          'benchmark_async.log',
+          :layout => pattern,
+          :write_size => write_size,
+          :auto_flushing => auto_flushing_size,
+          :async => true
+
+      logging_sync = ::Logging.logger['SyncFile']
+      logging_sync.level = :info
+      logging_sync.appenders = Logging.appenders.file \
+          'benchmark_sync.log',
+          :layout => pattern,
+          :write_size => write_size,
+          :auto_flushing => auto_flushing_size,
+          :async => false
+
+      puts "\n== File ==\n"
+      ::Benchmark.bm(20) do |bm|
+        bm.report('Logging (Async):') {this_many.times { |n| logging_async.info "Iteration #{n}"}}
+        bm.report('Logging (Sync):')  {this_many.times { |n| logging_sync.info  "Iteration #{n}"}}
+      end
+
+      File.delete('benchmark_async.log')
+      File.delete('benchmark_sync.log')
     end
-
-  end  # class Benchmark
-end  # module Logging
-
+  end
+end
 
 if __FILE__ == $0
   bm = ::Logging::Benchmark.new
   bm.run
 end
-

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -28,7 +28,7 @@ module Logging
       Logging.appenders.string_io('sio', :layout => pattern)
       sio = Logging.appenders['sio'].sio
 
-      logging = ::Logging.logger('benchmark')
+      logging = ::Logging.logger['benchmark']
       logging.level = :warn
       logging.appenders = 'sio'
 


### PR DESCRIPTION
These changes enable the existing periodic flushing mechanism to be used to asynchronously write the log buffer to the IO stream. By setting the `async` flag to true, the flusher Thread will be used to write messages thereby freeing up the main program thread to continue on doing other work.

refs #130 

/cc @thedrow