### PR TITLE
Thread safe log level

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -7,6 +7,7 @@ Enhancements
 - accessor methods for `backtrace` settings [PR #134]
 - asynchronous writing from buffered appenders [PR #135]
 - improve date format performance when outputting microseconds [PR #136]
+- added some thread safety to log level setters [PR #137]
 
 Bug Fixes
 - fixing encodings in tests [PR #116]

--- a/lib/logging/logger.rb
+++ b/lib/logging/logger.rb
@@ -87,13 +87,14 @@ module Logging
       logger
     end
 
+    # This generator is used to define the log methods for the given `level`.
+    # This code is evaluated in the context of a Logger instance.
     #
-    #
+    # Returns log methods as a String
     def self.log_methods_for_level( level )
       code = []
       ::Logging::LEVELS.each do |name,num|
         code << <<-CODE
-            # ---- #{name} ----
             undef :#{name}  if method_defined? :#{name}
             undef :#{name}? if method_defined? :#{name}?
         CODE

--- a/lib/logging/logger.rb
+++ b/lib/logging/logger.rb
@@ -54,7 +54,7 @@ module Logging
 
         logger = instantiate(name)
         repo[name] = logger
-        repo.children(name).each { |c| c.__send__(:parent=, logger) }
+        repo.children(name).each { |child| child.__send__(:parent=, logger) }
         logger
       end
     end
@@ -421,8 +421,8 @@ module Logging
 
       ::Logging::Logger._reentrant_mutex.synchronize do
         ::Logging::Logger.define_log_methods(self)
-        ::Logging::Repository.instance.children(name).each do |c|
-          c.define_log_methods
+        ::Logging::Repository.instance.children(name).each do |child|
+          child.define_log_methods
         end
       end
       self


### PR DESCRIPTION
The goal of this PR is to address some thread safety issues in the Logging framework. Namely assigning log levels to Loggers.

Because we have a hierarchy of Loggers, assigning a log level to one Logger affects all the children under that part of the hierarchy. The changes here lock the hierarchy via a mutex so that only one thread can modify the log levels at any given time.

refs #129 and #132 

/cc @perlun 