### PR TITLE
Removing use of syswrite

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -7,6 +7,7 @@ Enhancements
 - accessor methods for `backtrace` settings [PR #134]
 - asynchronous writing from buffered appenders [PR #135]
 - improve date format performance when outputting microseconds [PR #136]
+- use `write` everywhere instead of `syswrite` [PR #138]
 
 Bug Fixes
 - fixing encodings in tests [PR #116]

--- a/lib/logging/appenders/console.rb
+++ b/lib/logging/appenders/console.rb
@@ -1,4 +1,3 @@
-
 module Logging::Appenders
 
   # This class is provides an Appender base class for writing to the standard IO
@@ -34,18 +33,6 @@ module Logging::Appenders
     rescue NameError
       raise RuntimeError, "Please do not use the `Logging::Appenders::Console` class directly - " +
                           "use `Logging::Appenders::Stdout` and `Logging::Appenders::Stderr` instead"
-    end
-
-  private
-
-    # @override of ::Logging::Appenders::IO
-    def canonical_write( str )
-      return self if @io.nil?
-      str = str.force_encoding(encoding) if encoding && str.encoding != encoding
-      @io.write str # instead of syswrite
-      self
-    rescue StandardError => err
-      handle_internal_error(err)
     end
   end
 

--- a/lib/logging/appenders/io.rb
+++ b/lib/logging/appenders/io.rb
@@ -28,13 +28,12 @@ module Logging::Appenders
     # stream as the logging destination.
     #
     def initialize( name, io, opts = {} )
-      unless io.respond_to? :syswrite
+      unless io.respond_to? :write
         raise TypeError, "expecting an IO object but got '#{io.class.name}'"
       end
 
       @io = io
-      @io.sync = true if io.respond_to? :sync=    # syswrite complains if the IO stream is buffered
-      @io.flush rescue nil                        # syswrite also complains if in unbuffered mode and buffer isn't empty
+      @io.sync = true if io.respond_to? :sync=
       @close_method = :close
 
       super(name, opts)
@@ -71,7 +70,7 @@ module Logging::Appenders
     def canonical_write( str )
       return self if @io.nil?
       str = str.force_encoding(encoding) if encoding && str.encoding != encoding
-      @io.syswrite str
+      @io.write str
       self
     rescue StandardError => err
       handle_internal_error(err)

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -148,7 +148,7 @@ module Logging::Appenders
       return self if @io.nil?
 
       str = str.force_encoding(encoding) if encoding && str.encoding != encoding
-      @io.flock_sh { @io.syswrite str }
+      @io.flock_sh { @io.write str }
 
       if roll_required?
         @io.flock? {


### PR DESCRIPTION
Setting the `sync` flag to true on the IO stream and using the standard `write` method is just as performant as using `syswrite`. For the sake of avoiding unexpected surprises with mixed write/syswrite operations, I'm switching everything over to plain writes.

refs #127 