### PR TITLE
Fix a race condition in the rolling file appender

### DIFF
--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -144,6 +144,7 @@ module Logging::Appenders
     # Returns the modification time of the copy file if one exists. Otherwise
     # returns `nil`.
     def copy_file_mtime
+      return nil unless ::File.exist?(copy_file)
       ::File.mtime(copy_file)
     rescue Errno::ENOENT
       nil

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -141,6 +141,14 @@ module Logging::Appenders
       @roller.copy_file
     end
 
+    # Returns the modification time of the copy file if one exists. Otherwise
+    # returns `nil`.
+    def copy_file_mtime
+      ::File.mtime(copy_file)
+    rescue Errno::ENOENT
+      nil
+    end
+
     # Write the given _event_ to the log file. The log file will be rolled
     # if the maximum file size is exceeded or if the file is older than the
     # maximum age.
@@ -166,7 +174,8 @@ module Logging::Appenders
 
     # Returns +true+ if the log file needs to be rolled.
     def roll_required?
-      return false if ::File.exist?(copy_file) && (Time.now - ::File.mtime(copy_file)) < 180
+      mtime = copy_file_mtime
+      return false if mtime && (Time.now - mtime) < 180
 
       # check if max size has been exceeded
       s = @size ? ::File.size(filename) > @size : false


### PR DESCRIPTION
There is a race condition in determining the modification time of the "copy file" used for the copy/truncate rolling semantics. We first check if the file exists, but under some conditions the copy file can be deleted before the `mtime` is determined. This leads to an `ENOENT` exception.

The fix here is to let the exception happen, catch it, and return a `nil` modification time.

fixes #148 