### PR TITLE
Base path for file names

### DIFF
--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -311,6 +311,28 @@ module Logging
           end
     end
 
+    # Used to define a `basepath` that will be removed from filenames when
+    # reporting tracing information for log events. Normally you would set this
+    # to the root of your project:
+    #
+    #   Logging.basepath = "/home/user/nifty_project"
+    #
+    # Or if you are in a Rails environment:
+    #
+    #   Logging.basepath = Rails.root.to_s
+    #
+    # The basepath is expanded to full path with trailing slashes removed. This
+    # setting will be cleared by a call to `Logging.reset`.
+    def basepath=( path )
+      if path.nil? || path.to_s.empty?
+        @basepath = nil
+      else
+        @basepath = File.expand_path(path)
+      end
+    end
+
+    attr_reader :basepath
+
     # Returns the library path for the module. If any arguments are given,
     # they will be joined to the end of the library path using
     # <tt>File.join</tt>.
@@ -466,6 +488,7 @@ module Logging
       LEVELS.clear
       LNAMES.clear
       remove_instance_variable :@backtrace if defined? @backtrace
+      remove_instance_variable :@basepath  if defined? @basepath
       remove_const :MAX_LEVEL_LENGTH if const_defined? :MAX_LEVEL_LENGTH
       remove_const :OBJ_FORMAT if const_defined? :OBJ_FORMAT
       self

--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -321,8 +321,8 @@ module Logging
     #
     #   Logging.basepath = Rails.root.to_s
     #
-    # The basepath is expanded to full path with trailing slashes removed. This
-    # setting will be cleared by a call to `Logging.reset`.
+    # The basepath is expanded to a full path with trailing slashes removed.
+    # This setting will be cleared by a call to `Logging.reset`.
     def basepath=( path )
       if path.nil? || path.to_s.empty?
         @basepath = nil

--- a/lib/logging/log_event.rb
+++ b/lib/logging/log_event.rb
@@ -35,6 +35,10 @@ module Logging
         f = match[1]
         l = Integer(match[2])
         m = match[3] unless match[3].nil?
+
+        if (bp = ::Logging.basepath) && !bp.empty? && f.index(bp) == 0
+          f = f.slice(bp.length + 1, f.length - bp.length)
+        end
       end
 
       super(logger, level, data, Time.now, f, l, m)

--- a/test/test_log_event.rb
+++ b/test/test_log_event.rb
@@ -34,6 +34,14 @@ module TestLogging
       assert_match %r/test_log_event.rb\z/, @appender.event.file
     end
 
+    def test_file_with_basepath
+      ::Logging.basepath = File.expand_path("../../", __FILE__)
+
+      @logger.caller_tracing = true
+      @logger.warn "warning message"
+      assert_equal "test/test_log_event.rb", @appender.event.file
+    end
+
     def test_level
       assert_equal 1, @event.level
     end

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -39,6 +39,19 @@ module TestLogging
       assert_raise(ArgumentError) {::Logging.backtrace 'foo'}
     end
 
+    def test_basepath
+      assert_nil ::Logging.basepath
+
+      ::Logging.basepath = ""
+      assert_nil ::Logging.basepath
+
+      ::Logging.basepath = "./"
+      assert_equal File.expand_path("../../", __FILE__), ::Logging.basepath
+
+      ::Logging.reset
+      assert_nil ::Logging.basepath
+    end
+
     def test_logger
       assert_raise(TypeError) {::Logging.logger []}
 


### PR DESCRIPTION
This PR adds a `basepath` configuration for the Logging framework. When call tracing is enabled for log events, the reported filenames will be relative to this `basepath` setting.

```ruby
Logging.basepath = Rails.root.to_s
```

Now for your Rails project, all filenames are relative to that path. Messages will contain filenames like this `app/model/user.rb` instead of the longer `/home/sally/projects/rails_app/app/model/user.rb`.

fixes #126 

/cc @cshupp1 and @vanso-hubsi since you both might have some thoughts on the approach taken here