### PR TITLE
Make context inheritance optional

### DIFF
--- a/lib/logging/diagnostic_context.rb
+++ b/lib/logging/diagnostic_context.rb
@@ -404,6 +404,7 @@ Logging::INHERIT_CONTEXT =
   if ENV.key?("LOGGING_INHERIT_CONTEXT")
     case ENV["LOGGING_INHERIT_CONTEXT"].downcase
     when 'false', 'no', '0'; false
+    when false, nil; false
     else true end
   else
     true

--- a/lib/logging/diagnostic_context.rb
+++ b/lib/logging/diagnostic_context.rb
@@ -397,61 +397,70 @@ module Logging
   end
 
   DIAGNOSTIC_MUTEX = Mutex.new
-
-end  # module Logging
-
+end
 
 # :stopdoc:
-class Thread
-  class << self
-
-    %w[new start fork].each do |m|
-      class_eval <<-__, __FILE__, __LINE__
-        alias_method :_orig_#{m}, :#{m}
-        private :_orig_#{m}
-        def #{m}( *a, &b )
-          create_with_logging_context(:_orig_#{m}, *a ,&b)
-        end
-      __
-    end
-
-  private
-
-    # In order for the diagnostic contexts to behave properly we need to
-    # inherit state from the parent thread. The only way I have found to do
-    # this in Ruby is to override `new` and capture the contexts from the
-    # parent Thread at the time the child Thread is created. The code below does
-    # just this. If there is a more idiomatic way of accomplishing this in Ruby,
-    # please let me know!
-    #
-    # Also, great care is taken in this code to ensure that a reference to the
-    # parent thread does not exist in the binding associated with the block
-    # being executed in the child thread. The same is true for the parent
-    # thread's mdc and ndc. If any of those references end up in the binding,
-    # then they cannot be garbage collected until the child thread exits.
-    #
-    def create_with_logging_context( m, *a, &b )
-      mdc, ndc = nil
-
-      if Thread.current[Logging::MappedDiagnosticContext::STACK_NAME]
-        mdc = Logging::MappedDiagnosticContext.context.dup
-      end
-
-      if Thread.current[Logging::NestedDiagnosticContext::NAME]
-        ndc = Logging::NestedDiagnosticContext.context.dup
-      end
-
-      # This calls the actual `Thread#new` method to create the Thread instance.
-      # If your memory profiling tool says this method is leaking memory, then
-      # you are leaking Thread instances somewhere.
-      self.send(m, *a) { |*args|
-        Logging::MappedDiagnosticContext.inherit(mdc)
-        Logging::NestedDiagnosticContext.inherit(ndc)
-        b.call(*args)
-      }
-    end
-
+Logging::INHERIT_CONTEXT =
+  if ENV.key?("LOGGING_INHERIT_CONTEXT")
+    case ENV["LOGGING_INHERIT_CONTEXT"].downcase
+    when 'false', 'no', '0'; false
+    else true end
+  else
+    true
   end
-end  # Thread
+
+if Logging::INHERIT_CONTEXT
+  class Thread
+    class << self
+
+      %w[new start fork].each do |m|
+        class_eval <<-__, __FILE__, __LINE__
+          alias_method :_orig_#{m}, :#{m}
+          private :_orig_#{m}
+          def #{m}( *a, &b )
+            create_with_logging_context(:_orig_#{m}, *a ,&b)
+          end
+        __
+      end
+
+    private
+
+      # In order for the diagnostic contexts to behave properly we need to
+      # inherit state from the parent thread. The only way I have found to do
+      # this in Ruby is to override `new` and capture the contexts from the
+      # parent Thread at the time the child Thread is created. The code below does
+      # just this. If there is a more idiomatic way of accomplishing this in Ruby,
+      # please let me know!
+      #
+      # Also, great care is taken in this code to ensure that a reference to the
+      # parent thread does not exist in the binding associated with the block
+      # being executed in the child thread. The same is true for the parent
+      # thread's mdc and ndc. If any of those references end up in the binding,
+      # then they cannot be garbage collected until the child thread exits.
+      #
+      def create_with_logging_context( m, *a, &b )
+        mdc, ndc = nil
+
+        if Thread.current[Logging::MappedDiagnosticContext::STACK_NAME]
+          mdc = Logging::MappedDiagnosticContext.context.dup
+        end
+
+        if Thread.current[Logging::NestedDiagnosticContext::NAME]
+          ndc = Logging::NestedDiagnosticContext.context.dup
+        end
+
+        # This calls the actual `Thread#new` method to create the Thread instance.
+        # If your memory profiling tool says this method is leaking memory, then
+        # you are leaking Thread instances somewhere.
+        self.send(m, *a) { |*args|
+          Logging::MappedDiagnosticContext.inherit(mdc)
+          Logging::NestedDiagnosticContext.inherit(ndc)
+          b.call(*args)
+        }
+      end
+
+    end
+  end
+end
 # :startdoc:
 

--- a/test/test_mapped_diagnostic_context.rb
+++ b/test/test_mapped_diagnostic_context.rb
@@ -105,12 +105,21 @@ module TestLogging
 
         assert_not_equal context.object_id, Logging.mdc.context.object_id
 
-        assert_equal 1, Logging.mdc['foo']
-        assert_equal 'buz', Logging.mdc['baz']
-        assert_equal 'something else', Logging.mdc['foobar']
-        assert_nil Logging.mdc['unique']
+        if Logging::INHERIT_CONTEXT
+          assert_equal 1, Logging.mdc['foo']
+          assert_equal 'buz', Logging.mdc['baz']
+          assert_equal 'something else', Logging.mdc['foobar']
+          assert_nil Logging.mdc['unique']
 
-        assert_equal 1, Logging.mdc.stack.length
+          assert_equal 1, Logging.mdc.stack.length
+        else
+          assert_nil Logging.mdc['foo']
+          assert_nil Logging.mdc['baz']
+          assert_nil Logging.mdc['foobar']
+          assert_nil Logging.mdc['unique']
+
+          assert_equal 1, Logging.mdc.stack.length
+        end
       }
 
       Thread.pass until t.status == 'sleep'

--- a/test/test_nested_diagnostic_context.rb
+++ b/test/test_nested_diagnostic_context.rb
@@ -85,7 +85,12 @@ module TestLogging
         sleep
 
         assert_not_equal ary.object_id, Logging.ndc.context.object_id
-        assert_equal %w[first second], Logging.ndc.context
+
+        if Logging::INHERIT_CONTEXT
+          assert_equal %w[first second], Logging.ndc.context
+        else
+          assert_empty Logging.ndc.context
+        end
       }
 
       Thread.pass until t.status == 'sleep'


### PR DESCRIPTION
This code adds an environment flag that can be used to disable or enabled context inheritance. The diagnostic contexts are stored in a thread local variable. To inhert this context between threads, we have to override the `new`, `start`, and `fork` methods so that we have a handle on the parent thread's context.

The unfortunate downside of this is that we end up with `Logging` calls in backtraces for some exceptions involving threads. This can lead to confusion.

You can set the environment variable `LOGGING_INHERIT_CONTEXT` to `false` to disable this feature if you do not need it.

```sh
LOGGING_INHERIT_CONTEXT=false ruby your_code.rb
```

fixes #155

/cc @ivoanjo 