### PR TITLE
Use thread-local variables for diagnostic contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:        "rake gem:install_dependencies"
 script: "rake"
 
 rvm:
-  - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.10
   - 2.2.6

--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -452,7 +452,7 @@ module Logging
     # to false. It uses its own appender to send messages to stderr.
     #
     def show_configuration( io = STDOUT, logger = 'root', indent = 0 )
-      logger = ::Logging::Logger[logger] unless ::Logging::Logger === logger
+      logger = ::Logging::Logger[logger] unless logger.is_a?(::Logging::Logger)
 
       io << logger._dump_configuration(indent)
 

--- a/lib/logging/appenders/console.rb
+++ b/lib/logging/appenders/console.rb
@@ -24,7 +24,7 @@ module Logging::Appenders
       name = self.class.name.split("::").last.downcase
       io   = Object.const_get(name.upcase)
 
-      opts = Hash === args.last ? args.pop : {}
+      opts = args.last.is_a?(Hash) ? args.pop : {}
       name = args.shift unless args.empty?
 
       opts[:encoding] = io.external_encoding if io.respond_to? :external_encoding

--- a/lib/logging/color_scheme.rb
+++ b/lib/logging/color_scheme.rb
@@ -40,7 +40,7 @@ module Logging
       # Store a color scheme by name.
       #
       def []=( name, value )
-        raise ArgumentError, "Silly! That's not a ColorSchmeme!" unless ColorScheme === value
+        raise ArgumentError, "Silly! That's not a ColorSchmeme!" unless value.is_a?(ColorScheme)
         @color_schemes[name.to_s] = value
       end
 

--- a/lib/logging/diagnostic_context.rb
+++ b/lib/logging/diagnostic_context.rb
@@ -209,7 +209,7 @@ module Logging
     # Raises an ArgumentError if hash is not a Hash.
     #
     def sanitize( hash, target = {} )
-      unless Hash === hash
+      unless hash.is_a?(Hash)
         raise ArgumentError, "Expecting a Hash but received a #{hash.class.name}"
       end
 


### PR DESCRIPTION
When the Logging gem was originally written, Ruby Fibers did not exist. The syntax for setting a thread local variable was originally:

```ruby
Thread.current["variable"] = "value"
```

But with the advent of fibers, the meaning of the above syntax changed. Instead this syntax sets fiber local variables, and the syntax for setting a thread local variable changed to be:

```ruby
Thread.current.thread_variable_set("variable", "value")
```

This PR changes the Logging code back to using thread local variables as was the original intent.