### PR TITLE
Extend JSON layout with prefix

### DIFF
--- a/examples/layouts.rb
+++ b/examples/layouts.rb
@@ -26,6 +26,7 @@
     'development.log',
     :age    => 'daily',
     :layout => Logging.layouts.json
+    #:prefix => '@cee:' # optional logging cookie
   )
 
   log = Logging.logger['Foo::Bar']

--- a/test/layouts/test_json.rb
+++ b/test/layouts/test_json.rb
@@ -166,6 +166,30 @@ module TestLayouts
       assert_match %r/"ndc":\[\]/, format
     end
 
+    def test_prefix_missing
+      layout = Logging.layouts.json(:items => %w[timestamp])
+      event = Logging::LogEvent.new('TestLogger', @levels['info'], 'msg w/ cookie', false)
+      event.time = Time.utc(2016, 12, 1, 12, 0, 0).freeze
+
+      assert_equal %Q/{"timestamp":"2016-12-01T12:00:00.000000Z"}\n/, layout.format(event)
+    end
+
+    def test_prefix_present
+      layout = Logging.layouts.json(:items => %w[timestamp], :prefix => "@cee:")
+      event = Logging::LogEvent.new('TestLogger', @levels['info'], 'msg w/ cookie', false)
+      event.time = Time.utc(2016, 12, 1, 12, 0, 0).freeze
+
+      assert_equal %Q/@cee:{"timestamp":"2016-12-01T12:00:00.000000Z"}\n/, layout.format(event)
+    end
+
+    def test_prefix_empty
+      layout = Logging.layouts.json(:items => %w[timestamp], :prefix => "")
+      event = Logging::LogEvent.new('TestLogger', @levels['info'], 'msg w/ cookie', false)
+      event.time = Time.utc(2016, 12, 1, 12, 0, 0).freeze
+
+      assert_equal %Q/{"timestamp":"2016-12-01T12:00:00.000000Z"}\n/, layout.format(event)
+    end
+
     def test_utc_offset
       layout = Logging.layouts.json(:items => %w[timestamp])
       event = Logging::LogEvent.new('TimestampLogger', @levels['info'], 'log message', false)


### PR DESCRIPTION
Hello. Syslog implementation `rsyslog` has a module named mmjsonparse which is able to parse JSON data prefixed with special cookie. It can be set to arbitrary value, but de-facto standard is `@cee:` which stands for CEE initiative by MITRE and project Lumberjack hosted on Fedora.

While it is possible to set cookie-less parsing using this statement in rsyslog configuration:

    action(type="mmjsonparse" cookie="")

this must be done globally as mmjsonparse cannot be used in if-statement, therefore use of cookie prefix is unavoidable. This patch adds an extra option for JSON layout called "prefix" and if present, all messages are prefixed with an arbitrary string. The prefix is ignored for YAML where it's not relevant.

https://www.rsyslog.com/doc/master/configuration/modules/mmjsonparse.html