### PR TITLE
Handle simultaneous process startup

### DIFF
--- a/lib/logging/appenders/file.rb
+++ b/lib/logging/appenders/file.rb
@@ -2,14 +2,12 @@
 module Logging::Appenders
 
   # Accessor / Factory for the File appender.
-  #
   def self.file( *args )
     fail ArgumentError, '::Logging::Appenders::File needs a name as first argument.' if args.empty?
     ::Logging::Appenders::File.new(*args)
   end
 
   # This class provides an Appender that can write to a File.
-  #
   class File < ::Logging::Appenders::IO
 
     # call-seq:
@@ -21,7 +19,6 @@ module Logging::Appenders
     # writable.
     #
     # An +ArgumentError+ is raised if any of these assertions fail.
-    #
     def self.assert_valid_logfile( fn )
       if ::File.exist?(fn)
         if !::File.file?(fn)
@@ -45,7 +42,6 @@ module Logging::Appenders
     # created. If the :truncate option is set to +true+ then the file will
     # be truncated before writing begins; otherwise, log messages will be
     # appended to the file.
-    #
     def initialize( name, opts = {} )
       @filename = opts.fetch(:filename, name)
       raise ArgumentError, 'no filename was given' if @filename.nil?
@@ -72,7 +68,6 @@ module Logging::Appenders
     # Reopen the connection to the underlying logging destination. If the
     # connection is currently closed then it will be opened. If the connection
     # is currently open then it will be closed and immediately opened.
-    #
     def reopen
       @mutex.synchronize {
         if defined? @io && @io
@@ -99,6 +94,5 @@ module Logging::Appenders
     rescue Errno::EEXIST
       open_file
     end
-
   end
 end

--- a/lib/logging/appenders/io.rb
+++ b/lib/logging/appenders/io.rb
@@ -2,7 +2,6 @@
 module Logging::Appenders
 
   # Accessor / Factory for the IO appender.
-  #
   def self.io( *args )
     return ::Logging::Appenders::IO if args.empty?
     ::Logging::Appenders::IO.new(*args)
@@ -10,14 +9,12 @@ module Logging::Appenders
 
   # This class provides an Appender that can write to any IO stream
   # configured for writing.
-  #
   class IO < ::Logging::Appender
     include Buffering
 
     # The method that will be used to close the IO stream. Defaults to :close
     # but can be :close_read, :close_write or nil. When nil, the IO stream
     # will not be closed when the appender's close method is called.
-    #
     attr_accessor :close_method
 
     # call-seq:
@@ -26,7 +23,6 @@ module Logging::Appenders
     #
     # Creates a new IO Appender using the given name that will use the _io_
     # stream as the logging destination.
-    #
     def initialize( name, io, opts = {} )
       unless io.respond_to? :write
         raise TypeError, "expecting an IO object but got '#{io.class.name}'"
@@ -47,7 +43,6 @@ module Logging::Appenders
     # destination if the _footer_ flag is set to +true+. Log events will
     # no longer be written to the logging destination after the appender
     # is closed.
-    #
     def close( *args )
       return self if @io.nil?
       super
@@ -76,7 +71,6 @@ module Logging::Appenders
 
     # This method is called by the buffering code when messages need to be
     # written to the logging destination.
-    #
     def canonical_write( str )
       return self if @io.nil?
       str = str.force_encoding(encoding) if encoding && str.encoding != encoding
@@ -92,6 +86,5 @@ module Logging::Appenders
       ::Logging.log_internal {"appender #{name.inspect} has been disabled"}
       ::Logging.log_internal_error(err)
     end
-
-  end  # IO
-end  # Logging::Appenders
+  end
+end

--- a/lib/logging/appenders/io.rb
+++ b/lib/logging/appenders/io.rb
@@ -61,6 +61,16 @@ module Logging::Appenders
       return self
     end
 
+    # Reopen the connection to the underlying logging destination. If the
+    # connection is currently closed then it will be opened. If the connection
+    # is currently open then it will be closed and immediately opened. If
+    # supported, the IO will have its sync mode set to `true` so that all writes
+    # are immediately flushed to the underlying operating system.
+    def reopen
+      super
+      @io.sync = true if @io.respond_to? :sync=
+      self
+    end
 
   private
 

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -124,7 +124,6 @@ module TestAppenders
         Logging.appenders[NAME] = nil
       end
     end
-
   end  # TestFile
 
 end  # TestAppenders


### PR DESCRIPTION
There is a race condition in the File appender where two processes can attempt to open the same file at the same time. The changes here account for this by separating file opening from file creation.
    
Thanks to @sonots and his work fixing this same issue in the core Ruby Logger class. I've followed his approach to solve the same problem.