### PR TITLE
Synchronize log rolling

### DIFF
--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -160,11 +160,13 @@ module Logging::Appenders
       @io.flock_sh { @io.write str }
 
       if roll_required?
-        @io.flock? {
-          @age_fn_mtime = nil
-          copy_truncate if roll_required?
+        @mutex.synchronize {
+          @io.flock? {
+            @age_fn_mtime = nil
+            copy_truncate if roll_required?
+          }
+          @roller.roll_files
         }
-        @roller.roll_files
       end
       self
     rescue StandardError => err


### PR DESCRIPTION
There is a bug in the log rolling code where multiple threads in the same process can contend on rolling the files. The result is that we will delete log files and drop log messages. I grabbed the example from @lzap and modified the code a bit to get a better handle on the error.

```ruby
require 'logging'

filename = "tmp/rolling.log"

Logging.raise_errors = true
Logging.appenders.rolling_file filename,
  keep: 20,
  size: 400_000,
  age: 2,
  layout: Logging.layouts.pattern(pattern: "[%d] %T %5l -- %c: %m\n")

log = Logging.logger.root
log.add_appenders(Logging.appenders[filename])
log.level = :debug

threads = []

(1..30).each { |thread_count|
  threads << Thread.new do
    Thread.current[:name] = "T-%02d" % thread_count
    (1..1_000).each { |n|
      log.debug "#{n} a very nice little debug message"
      log.warn "#{n} this is your last warning"
    }
  end
}

threads.each {|t| t.join}
```

This little script will produce a total of 60,000 log lines. We can verify that all log lines are present by running this script and the counting the lines in the generated log files ...

```sh
> ruby -I lib roly.rb
> cat tmp/*.log | wc -l
60000
```

And now we are getting the expected 60000 log lines

refs #206
/cc @lzap 