### PR TITLE
Fix file creation race

### DIFF
--- a/lib/logging/appenders/file.rb
+++ b/lib/logging/appenders/file.rb
@@ -90,14 +90,14 @@ module Logging::Appenders
     end
 
     def open_file
-      mode = ::File::WRONLY |::File::APPEND
+      mode = ::File::WRONLY | ::File::APPEND
       ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::ENOENT
       create_file
     end
 
     def create_file
-      mode = ::File::WRONLY |::File::APPEND | ::File::CREAT | ::File::EXCL
+      mode = ::File::WRONLY | ::File::APPEND | ::File::CREAT | ::File::EXCL
       ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::EEXIST
       open_file

--- a/lib/logging/appenders/file.rb
+++ b/lib/logging/appenders/file.rb
@@ -49,17 +49,12 @@ module Logging::Appenders
       @filename = ::File.expand_path(@filename).freeze
       self.class.assert_valid_logfile(@filename)
 
-      @mode = ::File::WRONLY
-      if opts.fetch(:truncate, false)
-        @mode |= ::File::TRUNC
-      else
-        @mode |= ::File::APPEND
-      end
-
       self.encoding = opts.fetch(:encoding, self.encoding)
 
       io = open_file
       super(name, io, opts)
+
+      truncate if opts.fetch(:truncate, false)
     end
 
     # Returns the path to the logfile.
@@ -80,16 +75,29 @@ module Logging::Appenders
       self
     end
 
+
   protected
 
+    def truncate
+      @mutex.synchronize {
+        begin
+          @io.flock(::File::LOCK_EX)
+          @io.truncate(0)
+        ensure
+          @io.flock(::File::LOCK_UN)
+        end
+      }
+    end
+
     def open_file
-      ::File.open(filename, mode: @mode, external_encoding: encoding)
+      mode = ::File::WRONLY |::File::APPEND
+      ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::ENOENT
       create_file
     end
 
     def create_file
-      mode = @mode | ::File::CREAT | ::File::EXCL
+      mode = ::File::WRONLY |::File::APPEND | ::File::CREAT | ::File::EXCL
       ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::EEXIST
       open_file

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -106,8 +106,10 @@ module Logging::Appenders
 
       # we are opening the file in read/write mode so that a shared lock can
       # be used on the file descriptor => http://pubs.opengroup.org/onlinepubs/009695399/functions/fcntl.html
-      @mode = encoding ? "a+:#{encoding}" : 'a+'
-      super(name, ::File.new(filename, @mode), opts)
+      self.encoding = opts.fetch(:encoding, self.encoding)
+
+      io = open_file
+      super(name, io, opts)
 
       # if the truncate flag was set to true, then roll
       roll_now = opts.fetch(:truncate, false)
@@ -127,11 +129,11 @@ module Logging::Appenders
     # is currently open then it will be closed and immediately opened.
     def reopen
       @mutex.synchronize {
-        if defined?(@io) && @io
+        if defined? @io && @io
           flush
           @io.close rescue nil
         end
-        @io = ::File.new(filename, @mode)
+        @io = open_file
       }
       super
       self
@@ -139,6 +141,20 @@ module Logging::Appenders
 
 
   private
+
+    def open_file
+      mode = ::File::RDWR |::File::APPEND
+      ::File.open(filename, mode: mode, external_encoding: encoding)
+    rescue Errno::ENOENT
+      create_file
+    end
+
+    def create_file
+      mode = ::File::RDWR |::File::APPEND | ::File::CREAT | ::File::EXCL
+      ::File.open(filename, mode: mode, external_encoding: encoding)
+    rescue Errno::EEXIST
+      open_file
+    end
 
     # Returns the file name to use as the temporary copy location. We are
     # using copy-and-truncate semantics for rolling files so that the IO
@@ -206,7 +222,7 @@ module Logging::Appenders
 # puts "[#{Thread.current[:name]}]     copy_truncate"
       return unless ::File.exist?(filename)
       FileUtils.concat filename, copy_file
-      @io.truncate 0
+      @io.truncate(0)
 
       # touch the age file if needed
       if @age

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -143,14 +143,14 @@ module Logging::Appenders
   private
 
     def open_file
-      mode = ::File::RDWR |::File::APPEND
+      mode = ::File::RDWR | ::File::APPEND
       ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::ENOENT
       create_file
     end
 
     def create_file
-      mode = ::File::RDWR |::File::APPEND | ::File::CREAT | ::File::EXCL
+      mode = ::File::RDWR | ::File::APPEND | ::File::CREAT | ::File::EXCL
       ::File.open(filename, mode: mode, external_encoding: encoding)
     rescue Errno::EEXIST
       open_file

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -85,11 +85,11 @@ module Logging::Appenders
     #
     def initialize( name, opts = {} )
       @roller = Roller.new(
-        filename: opts.fetch(:filename, name),
-        age: opts.fetch(:age, nil),
-        size: opts.fetch(:size, nil),
+        opts.fetch(:filename, name),
+        age:     opts.fetch(:age, nil),
+        size:    opts.fetch(:size, nil),
         roll_by: opts.fetch(:roll_by, nil),
-        keep: opts.fetch(:keep, nil)
+        keep:    opts.fetch(:keep, nil)
       )
 
       # grab our options
@@ -285,7 +285,7 @@ module Logging::Appenders
       # roll_by  - roll either by 'number' or 'date'
       # keep     - the number of log files to keep when rolling
       #
-      def initialize( filename:, age: nil, size: nil, roll_by: nil, keep: nil )
+      def initialize( filename, age: nil, size: nil, roll_by: nil, keep: nil )
         # raise an error if a filename was not given
         @fn = filename
         raise ArgumentError, 'no filename was given' if @fn.nil?

--- a/lib/logging/appenders/rolling_file.rb
+++ b/lib/logging/appenders/rolling_file.rb
@@ -183,15 +183,11 @@ module Logging::Appenders
 
       if roll_required?
         @mutex.synchronize {
-# puts "[#{Thread.current[:name]}] mutex"
           @io.flock? {
-# puts "[#{Thread.current[:name]}]   flock"
             @age_fn_mtime = nil
             copy_truncate if roll_required?
-# puts "[#{Thread.current[:name]}]   kcolf"
           }
           @roller.roll_files
-# puts "[#{Thread.current[:name]}] xetum"
         }
       end
       self
@@ -219,7 +215,6 @@ module Logging::Appenders
     # to zero length. This method will set the roll flag so that all the
     # current logfiles will be rolled along with the copied file.
     def copy_truncate
-# puts "[#{Thread.current[:name]}]     copy_truncate"
       return unless ::File.exist?(filename)
       FileUtils.concat filename, copy_file
       @io.truncate(0)
@@ -370,13 +365,11 @@ module Logging::Appenders
       # Returns nil
       def roll_files
         return unless roll && ::File.exist?(copy_file)
-# puts "[#{Thread.current[:name]}]   roll_files"
 
         files = Dir.glob(glob)
         files.delete copy_file
 
         self.send "roll_by_#{roll_by}", files
-
         nil
       ensure
         self.roll = false

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -117,6 +117,25 @@ module TestAppenders
       cleanup
     end
 
+    def test_reopening_should_not_truncate_the_file
+      log = File.join(@tmpdir, 'truncate.log')
+      appender = Logging.appenders.file(NAME, filename: log, truncate: true)
+
+      appender << "This will be the first line\n"
+      appender << "This will be the second line\n"
+      appender << "This will be the third line\n"
+      appender.reopen
+
+      File.open(log, 'r') do |file|
+        assert_equal "This will be the first line\n", file.readline
+        assert_equal "This will be the second line\n", file.readline
+        assert_equal "This will be the third line\n", file.readline
+        assert_raise(EOFError) {file.readline}
+      end
+
+      cleanup
+    end
+
   private
     def cleanup
       unless Logging.appenders[NAME].nil?

--- a/test/appenders/test_file.rb
+++ b/test/appenders/test_file.rb
@@ -14,10 +14,10 @@ module TestAppenders
       super
       Logging.init
 
-      FileUtils.mkdir [File.join(TMP, 'dir'), File.join(TMP, 'uw_dir')]
-      FileUtils.chmod 0555, File.join(TMP, 'uw_dir')
-      FileUtils.touch File.join(TMP, 'uw_file')
-      FileUtils.chmod 0444, File.join(TMP, 'uw_file')
+      FileUtils.mkdir [File.join(@tmpdir, 'dir'), File.join(@tmpdir, 'uw_dir')]
+      FileUtils.chmod 0555, File.join(@tmpdir, 'uw_dir')
+      FileUtils.touch File.join(@tmpdir, 'uw_file')
+      FileUtils.chmod 0444, File.join(@tmpdir, 'uw_file')
     end
 
     def test_factory_method_validates_input
@@ -27,27 +27,27 @@ module TestAppenders
     end
 
     def test_class_assert_valid_logfile
-      log = File.join(TMP, 'uw_dir', 'file.log')
+      log = File.join(@tmpdir, 'uw_dir', 'file.log')
       assert_raise(ArgumentError) do
         Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
-      log = File.join(TMP, 'dir')
+      log = File.join(@tmpdir, 'dir')
       assert_raise(ArgumentError) do
         Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
-      log = File.join(TMP, 'uw_file')
+      log = File.join(@tmpdir, 'uw_file')
       assert_raise(ArgumentError) do
         Logging.appenders.file(log).class.assert_valid_logfile(log)
       end
 
-      log = File.join(TMP, 'file.log')
+      log = File.join(@tmpdir, 'file.log')
       assert Logging.appenders.file(log).class.assert_valid_logfile(log)
     end
 
     def test_initialize
-      log = File.join(TMP, 'file.log')
+      log = File.join(@tmpdir, 'file.log')
       appender = Logging.appenders.file(NAME, :filename => log)
       assert_equal 'logfile', appender.name
       assert_equal ::File.expand_path(log), appender.filename
@@ -87,7 +87,7 @@ module TestAppenders
     end
 
     def test_changing_directories
-      log = File.join(TMP, 'file.log')
+      log = File.join(@tmpdir, 'file.log')
       appender = Logging.appenders.file(NAME, :filename => log)
 
       assert_equal 'logfile', appender.name
@@ -95,7 +95,7 @@ module TestAppenders
 
       begin
         pwd = Dir.pwd
-        Dir.chdir TMP
+        Dir.chdir @tmpdir
         assert_nothing_raised { appender.reopen }
       ensure
         Dir.chdir pwd
@@ -103,7 +103,7 @@ module TestAppenders
     end
 
     def test_encoding
-      log = File.join(TMP, 'file-encoding.log')
+      log = File.join(@tmpdir, 'file-encoding.log')
       appender = Logging.appenders.file(NAME, :filename => log, :encoding => 'ASCII')
 
       appender << "A normal line of text\n"

--- a/test/appenders/test_rolling_file.rb
+++ b/test/appenders/test_rolling_file.rb
@@ -13,9 +13,9 @@ module TestAppenders
       super
       Logging.init
 
-      @fn = File.expand_path('test.log', TMP)
-      @fn_fmt = File.expand_path('test.%d.log', TMP)
-      @glob = File.expand_path('*.log', TMP)
+      @fn = File.expand_path('test.log', @tmpdir)
+      @fn_fmt = File.expand_path('test.%d.log', @tmpdir)
+      @glob = File.expand_path('*.log', @tmpdir)
     end
 
     def test_factory_method_validates_input
@@ -93,8 +93,8 @@ module TestAppenders
     end
 
     def test_age
-      d_glob = File.join(TMP, 'test.*.log')
-      dt_glob = File.join(TMP, 'test.*-*.log')
+      d_glob = File.join(@tmpdir, 'test.*.log')
+      dt_glob = File.join(@tmpdir, 'test.*-*.log')
       age_fn = @fn + '.age'
 
       assert_equal [], Dir.glob(@glob)
@@ -205,7 +205,7 @@ module TestAppenders
 
       begin
         pwd = Dir.pwd
-        Dir.chdir TMP
+        Dir.chdir @tmpdir
 
         ap << 'X' * 100; ap.flush
         assert_equal 1, Dir.glob(@glob).length
@@ -249,9 +249,9 @@ module TestAppenders
     end
 
     def test_custom_numberd_filename
-      fn = File.expand_path('test.log{{.%d}}', TMP)
-      filename = File.expand_path('test.log', TMP)
-      glob = File.expand_path('test.log.*', TMP)
+      fn = File.expand_path('test.log{{.%d}}', @tmpdir)
+      filename = File.expand_path('test.log', @tmpdir)
+      glob = File.expand_path('test.log.*', @tmpdir)
 
       assert_equal [], Dir.glob(glob)
       ap = Logging.appenders.rolling_file(NAME, :filename => fn, :size => 100, :keep => 2)
@@ -285,10 +285,10 @@ module TestAppenders
     end
 
     def test_custom_timestamp_filename
-      fn = File.expand_path('test{{.%S:%M}}.log', TMP)
-      filename = File.expand_path('test.log', TMP)
+      fn = File.expand_path('test{{.%S:%M}}.log', @tmpdir)
+      filename = File.expand_path('test.log', @tmpdir)
       age_file = filename + '.age'
-      glob = File.expand_path('test.*.log', TMP)
+      glob = File.expand_path('test.*.log', @tmpdir)
 
       assert_equal [], Dir.glob(glob)
       ap = Logging.appenders.rolling_file(NAME, :filename => fn, :age => 1, :keep => 2)

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -5,6 +5,12 @@ LOGGING_TEST_SETUP = true
 
 require "rubygems"
 require "test/unit"
+require "tmpdir"
+
+LOGGING_TEST_TMPDIR = Dir.mktmpdir("logging")
+Test::Unit.at_exit do
+  FileUtils.remove_entry(LOGGING_TEST_TMPDIR)
+end
 
 if Test::Unit::TestCase.respond_to? :test_order=
   Test::Unit::TestCase.test_order = :random
@@ -15,18 +21,16 @@ require File.expand_path("../../lib/logging", __FILE__)
 module TestLogging
   module LoggingTestCase
 
-    TMP = 'tmp'
-
     def setup
       super
       Logging.reset
-      FileUtils.rm_rf TMP
-      FileUtils.mkdir TMP
+      @tmpdir = LOGGING_TEST_TMPDIR
+      FileUtils.rm_rf(Dir.glob(File.join(@tmpdir, "*")))
     end
 
     def teardown
       super
-      FileUtils.rm_rf TMP
+      FileUtils.rm_rf(Dir.glob(File.join(@tmpdir, "*")))
     end
   end
 end

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -11,8 +11,8 @@ module TestLogging
       @levels = ::Logging::LEVELS
       @lnames = ::Logging::LNAMES
 
-      @fn = File.join(TMP, 'test.log')
-      @glob = File.join(TMP, '*.log')
+      @fn = File.join(@tmpdir, 'test.log')
+      @glob = File.join(@tmpdir, '*.log')
     end
 
     def test_backtrace


### PR DESCRIPTION
This PR fixes a race condition when multiple processes are attempting to create the same log file at startup. The solution is to try to open the file and fallback to creating if opening doesn't work. This solution has been applied to both the normal file appender and the rolling file appender.