### PR TITLE
Rename method to avoid conflict with Kernel

### DIFF
--- a/lib/logging/layouts/parseable.rb
+++ b/lib/logging/layouts/parseable.rb
@@ -103,7 +103,7 @@ module Logging::Layouts
       'message'   => 'format_obj(event.data)'.freeze,
       'file'      => 'event.file'.freeze,
       'line'      => 'event.line'.freeze,
-      'method'    => 'event.method'.freeze,
+      'method'    => 'event.method_name'.freeze,
       'hostname'  => "'#{Socket.gethostname}'".freeze,
       'pid'       => 'Process.pid'.freeze,
       'millis'    => 'Integer((event.time-@created_at)*1000)'.freeze,

--- a/lib/logging/layouts/pattern.rb
+++ b/lib/logging/layouts/pattern.rb
@@ -307,7 +307,7 @@ module Logging::Layouts
         'l' => '::Logging::LNAMES[event.level]'.freeze,
         'L' => 'event.line'.freeze,
         'm' => 'format_obj(event.data)'.freeze,
-        'M' => 'event.method'.freeze,
+        'M' => 'event.method_name'.freeze,
         'h' => "'#{Socket.gethostname}'".freeze,
         'p' => 'Process.pid'.freeze,
         'r' => 'Integer((event.time-@created_at)*1000).to_s'.freeze,

--- a/lib/logging/log_event.rb
+++ b/lib/logging/log_event.rb
@@ -15,7 +15,7 @@ module Logging
     CALLER_INDEX = ((defined? JRUBY_VERSION and JRUBY_VERSION > '1.6') or (defined? RUBY_ENGINE and RUBY_ENGINE[%r/^rbx/i])) ? 1 : 2
     # :startdoc:
 
-    attr_accessor :logger, :level, :data, :time, :file, :line, :method
+    attr_accessor :logger, :level, :data, :time, :file, :line, :method_name
 
     # call-seq:
     #    LogEvent.new( logger, level, [data], caller_tracing )
@@ -36,15 +36,15 @@ module Logging
         return if stack.nil?
 
         match = CALLER_RGXP.match(stack)
-        self.file   = match[1]
-        self.line   = Integer(match[2])
-        self.method = match[3] unless match[3].nil?
+        self.file = match[1]
+        self.line = Integer(match[2])
+        self.method_name = match[3] unless match[3].nil?
 
         if (bp = ::Logging.basepath) && !bp.empty? && file.index(bp) == 0
           self.file = file.slice(bp.length + 1, file.length - bp.length)
         end
       else
-        self.file = self.line = self.method = ''
+        self.file = self.line = self.method_name = ''
       end
     end
   end

--- a/test/layouts/test_json.rb
+++ b/test/layouts/test_json.rb
@@ -78,7 +78,7 @@ module TestLayouts
                                     'log message', false)
       event.file = 'test_file.rb'
       event.line = 123
-      event.method = 'method_name'
+      event.method_name = 'method_name'
 
       @layout.items = %w[logger]
       assert_equal %Q[{"logger":"TestLogger"}\n], @layout.format(event)

--- a/test/layouts/test_pattern.rb
+++ b/test/layouts/test_pattern.rb
@@ -105,7 +105,7 @@ module TestLayouts
                                     'log message', false)
       event.file = 'test_file.rb'
       event.line = '123'
-      event.method = 'method_name'
+      event.method_name = 'method_name'
 
       @layout.pattern = '%c'
       assert_equal 'TestLogger', @layout.format(event)

--- a/test/layouts/test_yaml.rb
+++ b/test/layouts/test_yaml.rb
@@ -68,7 +68,7 @@ module TestLayouts
                                     'log message', false)
       event.file = 'test_file.rb'
       event.line = 123
-      event.method = 'method_name'
+      event.method_name = 'method_name'
 
       @layout.items = %w[logger]
       assert_match %r/\A--- ?\nlogger: TestLogger\n/, @layout.format(event)

--- a/test/test_log_event.rb
+++ b/test/test_log_event.rb
@@ -68,12 +68,12 @@ module TestLogging
       assert_equal 'MyLogger', @event.logger
     end
 
-    def test_method
+    def test_method_name
       assert_equal '', @event.file
 
       @logger.caller_tracing = true
       @logger.debug 'debug message'
-      assert_equal 'test_method', @appender.event.method
+      assert_equal 'test_method_name', @appender.event.method_name
     end
 
   end  # class TestLogEvent


### PR DESCRIPTION
Renaming the `LogEvent#method` accessor to avoid conflicting with `Kernel#method`. This will cause exceptions when other classes attempt to invoke `method` on LogEvent with the wrong number of arguments.

fixes #211