### PR TITLE
Fix up console appenders

### DIFF
--- a/lib/logging/appenders/console.rb
+++ b/lib/logging/appenders/console.rb
@@ -52,10 +52,10 @@ module Logging::Appenders
     def open_fd
       case self.class.name.split("::").last.downcase
       when "stdout"
-        fd = 1
+        fd = STDOUT.fileno
         encoding = STDOUT.external_encoding
       when "stderr"
-        fd = 2
+        fd = STDERR.fileno
         encoding = STDERR.external_encoding
       else
         raise RuntimeError, "Please do not use the `Logging::Appenders::Console` class directly - " +

--- a/test/appenders/test_console.rb
+++ b/test/appenders/test_console.rb
@@ -25,11 +25,6 @@ module TestAppenders
       refute_same STDOUT, io
       assert_equal STDOUT.fileno, io.fileno
 
-      appender.close
-      assert appender.closed?
-      assert io.closed?
-      refute STDOUT.closed?
-
       appender = Logging.appenders.stdout('foo')
       assert_equal 'foo', appender.name
 
@@ -42,7 +37,26 @@ module TestAppenders
       assert_equal 3, appender.level
     end
 
-  end  # class TestStdout
+    def test_reopen
+      Logging::Repository.instance
+
+      appender = Logging.appenders.stdout
+      io = appender.instance_variable_get(:@io)
+
+      appender.close
+      assert appender.closed?
+      assert io.closed?
+      refute STDOUT.closed?
+
+      appender.reopen
+      refute appender.closed?
+
+      new_io = appender.instance_variable_get(:@io)
+      refute_same io, new_io
+      refute new_io.closed?
+      assert io.closed?
+    end
+  end
 
   class TestStderr < Test::Unit::TestCase
     include LoggingTestCase
@@ -57,11 +71,6 @@ module TestAppenders
       refute_same STDERR, io
       assert_same STDERR.fileno, io.fileno
 
-      appender.close
-      assert appender.closed?
-      assert io.closed?
-      refute STDERR.closed?
-
       appender = Logging.appenders.stderr('foo')
       assert_equal 'foo', appender.name
 
@@ -74,8 +83,26 @@ module TestAppenders
       assert_equal 3, appender.level
     end
 
-  end  # class TestStderr
+    def test_reopen
+      Logging::Repository.instance
 
-end  # module TestAppenders
-end  # module TestLogging
+      appender = Logging.appenders.stderr
+      io = appender.instance_variable_get(:@io)
+
+      appender.close
+      assert appender.closed?
+      assert io.closed?
+      refute STDERR.closed?
+
+      appender.reopen
+      refute appender.closed?
+
+      new_io = appender.instance_variable_get(:@io)
+      refute_same io, new_io
+      refute new_io.closed?
+      assert io.closed?
+    end
+  end
+end
+end
 

--- a/test/appenders/test_console.rb
+++ b/test/appenders/test_console.rb
@@ -20,11 +20,15 @@ module TestAppenders
 
       appender = Logging.appenders.stdout
       assert_equal 'stdout', appender.name
-      assert_same STDOUT, appender.instance_variable_get(:@io)
+
+      io = appender.instance_variable_get(:@io)
+      refute_same STDOUT, io
+      assert_equal STDOUT.fileno, io.fileno
 
       appender.close
-      assert_equal true, appender.closed?
-      assert_equal false, STDOUT.closed?
+      assert appender.closed?
+      assert io.closed?
+      refute STDOUT.closed?
 
       appender = Logging.appenders.stdout('foo')
       assert_equal 'foo', appender.name
@@ -48,11 +52,15 @@ module TestAppenders
 
       appender = Logging.appenders.stderr
       assert_equal 'stderr', appender.name
-      assert_same STDERR, appender.instance_variable_get(:@io)
+
+      io = appender.instance_variable_get(:@io)
+      refute_same STDERR, io
+      assert_same STDERR.fileno, io.fileno
 
       appender.close
-      assert_equal true, appender.closed?
-      assert_equal false, STDERR.closed?
+      assert appender.closed?
+      assert io.closed?
+      refute STDERR.closed?
 
       appender = Logging.appenders.stderr('foo')
       assert_equal 'foo', appender.name


### PR DESCRIPTION
This PR changes how the `Stdout` and `Stderr` conosle appenders work. Instead of reusing the Ruby constants `STDOUT` and `STDERR`, these appenders now create their own IO objects to use under the hood. These appenders have better behavior and can be closed and reopened.

fixes #214 