### PR TITLE
Add license to gemspec file

### DIFF
--- a/logging.gemspec
+++ b/logging.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.name = "logging".freeze
   s.version = "2.3.0"
 
+  s.license  = "MIT"
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Tim Pease".freeze]


### PR DESCRIPTION
Without the license being set, rubygems does not display the correct
license information.