### PR TITLE
Drop EOL Ruby versions from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ install:        "rake gem:install_dependencies"
 script: "rake"
 
 rvm:
-  - 2.0.0-p648
-  - 2.1.10
-  - 2.2.7
-  - 2.3.8
   - 2.4.9
   - 2.5.7
   - 2.6.5


### PR DESCRIPTION
Those versions are EOL and travis cannot resolve the dependencies
properly anymore.