### PR TITLE
Add context inheritance via `prepend` instead of changing `Thread`

### DIFF
--- a/lib/logging/diagnostic_context.rb
+++ b/lib/logging/diagnostic_context.rb
@@ -412,6 +412,48 @@ module Logging
   end
 
   DIAGNOSTIC_MUTEX = Mutex.new
+
+  module InheritContext
+    %w[new start fork].each do |m|
+      # In order for the diagnostic contexts to behave properly we need to
+      # inherit state from the parent thread. The only way I have found to do
+      # this in Ruby is to override `new` and capture the contexts from the
+      # parent Thread at the time the child Thread is created. The code below does
+      # just this. If there is a more idiomatic way of accomplishing this in Ruby,
+      # please let me know!
+      #
+      # Also, great care is taken in this code to ensure that a reference to the
+      # parent thread does not exist in the binding associated with the block
+      # being executed in the child thread. The same is true for the parent
+      # thread's mdc and ndc. If any of those references end up in the binding,
+      # then they cannot be garbage collected until the child thread exits.
+      class_eval <<-__, __FILE__, __LINE__
+        def #{m}( *args )
+          mdc, ndc = nil
+
+          if Thread.current.thread_variable_get(Logging::MappedDiagnosticContext::STACK_NAME)
+            mdc = Logging::MappedDiagnosticContext.context.dup
+          end
+
+          if Thread.current.thread_variable_get(Logging::NestedDiagnosticContext::NAME)
+            ndc = Logging::NestedDiagnosticContext.context.dup
+          end
+
+          wrapped_block = proc { |*thread_args|
+            Logging::MappedDiagnosticContext.inherit(mdc)
+            Logging::NestedDiagnosticContext.inherit(ndc)
+
+            yield(*thread_args)
+          }
+
+          # This calls the actual method to create the Thread instance.
+          # If your memory profiling tool says this method is leaking memory, then
+          # you are leaking Thread instances somewhere.
+          super(*args, &wrapped_block)
+        end
+      __
+    end
+  end
 end
 
 # :stopdoc:
@@ -426,57 +468,6 @@ Logging::INHERIT_CONTEXT =
   end
 
 if Logging::INHERIT_CONTEXT
-  class Thread
-    class << self
-
-      %w[new start fork].each do |m|
-        class_eval <<-__, __FILE__, __LINE__
-          alias_method :_orig_#{m}, :#{m}
-          private :_orig_#{m}
-          def #{m}( *a, &b )
-            create_with_logging_context(:_orig_#{m}, *a ,&b)
-          end
-        __
-      end
-
-    private
-
-      # In order for the diagnostic contexts to behave properly we need to
-      # inherit state from the parent thread. The only way I have found to do
-      # this in Ruby is to override `new` and capture the contexts from the
-      # parent Thread at the time the child Thread is created. The code below does
-      # just this. If there is a more idiomatic way of accomplishing this in Ruby,
-      # please let me know!
-      #
-      # Also, great care is taken in this code to ensure that a reference to the
-      # parent thread does not exist in the binding associated with the block
-      # being executed in the child thread. The same is true for the parent
-      # thread's mdc and ndc. If any of those references end up in the binding,
-      # then they cannot be garbage collected until the child thread exits.
-      #
-      def create_with_logging_context( m, *a, &b )
-        mdc, ndc = nil
-
-        if Thread.current.thread_variable_get(Logging::MappedDiagnosticContext::STACK_NAME)
-          mdc = Logging::MappedDiagnosticContext.context.dup
-        end
-
-        if Thread.current.thread_variable_get(Logging::NestedDiagnosticContext::NAME)
-          ndc = Logging::NestedDiagnosticContext.context.dup
-        end
-
-        # This calls the actual `Thread#new` method to create the Thread instance.
-        # If your memory profiling tool says this method is leaking memory, then
-        # you are leaking Thread instances somewhere.
-        self.send(m, *a) { |*args|
-          Logging::MappedDiagnosticContext.inherit(mdc)
-          Logging::NestedDiagnosticContext.inherit(ndc)
-          b.call(*args)
-        }
-      end
-
-    end
-  end
+  ::Thread.singleton_class.prepend(Logging::InheritContext)
 end
 # :startdoc:
-

--- a/lib/logging/diagnostic_context.rb
+++ b/lib/logging/diagnostic_context.rb
@@ -445,12 +445,14 @@ module Logging
 
             yield(*thread_args)
           }
+          wrapped_block.ruby2_keywords if wrapped_block.respond_to?(:ruby2_keywords, true)
 
           # This calls the actual method to create the Thread instance.
           # If your memory profiling tool says this method is leaking memory, then
           # you are leaking Thread instances somewhere.
           super(*args, &wrapped_block)
         end
+        ruby2_keywords :#{m} if respond_to?(:ruby2_keywords, true)
       __
     end
   end

--- a/test/test_mapped_diagnostic_context.rb
+++ b/test/test_mapped_diagnostic_context.rb
@@ -131,5 +131,13 @@ module TestLogging
       t.join
     end
 
+    def test_thread_patches_work_correctly_on_ruby3
+      the_args, the_kwargs = Thread.new(1, 2, 3, four: 4, five: 5) { |*args, **kwargs|
+        [args, kwargs]
+      }.value
+
+      assert_equal [1, 2, 3], the_args
+      assert_equal ({four: 4, five: 5}), the_kwargs
+    end
   end  # class TestMappedDiagnosticContext
 end  # module TestLogging


### PR DESCRIPTION
👋  Hello there!

I work at @Datadog on our open-source Ruby APM library, [`ddtrace`](https://github.com/DataDog/dd-trace-rb).

One of our users has ran into an issue where `logging`'s `Thread` inherit context behavior was conflicting with dd-trace's own extensions to `Thread`, leading to a `stack level too deep (SystemStackError)` due to both of our extensions conflicting.

We've seen this happen from time to time, e.g. https://github.com/rollbar/rollbar-gem/pull/1018 or https://github.com/MiniProfiler/rack-mini-profiler/pull/444.

Changing `logging` to use `prepend` makes it compatible with all libraries that have moved to use `prepend`.

Furthermore, while I was in the neighbourhood, I've added the tweaks necessary to not break Ruby 3.0 keyword arguments when used with threads, as well as a test to cover it.

I've tested these changes with Ruby 2.4, 2.7 and 3.0.

Hopefully this change is acceptable? Let me know if I can provide any more info or help, as we're really interested in solving this 😀