### PR TITLE
Fixes for JRuby

### DIFF
--- a/lib/logging/appenders/console.rb
+++ b/lib/logging/appenders/console.rb
@@ -39,7 +39,11 @@ module Logging::Appenders
       @mutex.synchronize {
         if defined? @io && @io
           flush
-          @io.close rescue nil
+          # JRuby will close the underlying file descriptor, so we don't want to
+          # do that even though this is a copy of STDOUT / STDERR
+          if !defined?(JRUBY_VERSION)
+            @io.close rescue nil
+          end
         end
         @io = open_fd
       }

--- a/lib/logging/appenders/io.rb
+++ b/lib/logging/appenders/io.rb
@@ -48,16 +48,9 @@ module Logging::Appenders
       super
 
       io, @io = @io, nil
-
-      # JRuby will always close the underlying file descriptor, so we need to
-      # check the FD number and not just the Ruby object ID
-      close_io = if defined?(JRUBY_VERSION)
-        ![STDIN.fileno, STDERR.fileno, STDOUT.fileno].include?(io.fileno)
-      else
-        ![STDIN, STDERR, STDOUT].include?(io)
+      if ![STDIN, STDERR, STDOUT].include?(io)
+        io.send(@close_method) if @close_method && io.respond_to?(@close_method)
       end
-
-      io.send(@close_method) if close_io && @close_method && io.respond_to?(@close_method)
     rescue IOError
     ensure
       return self

--- a/lib/logging/appenders/io.rb
+++ b/lib/logging/appenders/io.rb
@@ -48,9 +48,16 @@ module Logging::Appenders
       super
 
       io, @io = @io, nil
-      unless [STDIN, STDERR, STDOUT].include?(io)
-        io.send(@close_method) if @close_method && io.respond_to?(@close_method)
+
+      # JRuby will always close the underlying file descriptor, so we need to
+      # check the FD number and not just the Ruby object ID
+      close_io = if defined?(JRUBY_VERSION)
+        ![STDIN.fileno, STDERR.fileno, STDOUT.fileno].include?(io.fileno)
+      else
+        ![STDIN, STDERR, STDOUT].include?(io)
       end
+
+      io.send(@close_method) if close_io && @close_method && io.respond_to?(@close_method)
     rescue IOError
     ensure
       return self

--- a/lib/logging/log_event.rb
+++ b/lib/logging/log_event.rb
@@ -12,7 +12,8 @@ module Logging
     # * $3 == method name (might be nil)
     CALLER_RGXP = %r/([-\.\/\(\)\w]+):(\d+)(?::in `([^']+)')?/o
     #CALLER_INDEX = 2
-    CALLER_INDEX = ((defined? JRUBY_VERSION and JRUBY_VERSION > '1.6') or (defined? RUBY_ENGINE and RUBY_ENGINE[%r/^rbx/i])) ? 1 : 2
+    CALLER_INDEX = ((defined?(JRUBY_VERSION) && JRUBY_VERSION > '1.6' && JRUBY_VERSION < '9.0') ||
+                    (defined?(RUBY_ENGINE) && RUBY_ENGINE[%r/^rbx/i])) ? 1 : 2
     # :startdoc:
 
     attr_accessor :logger, :level, :data, :time, :file, :line, :method_name

--- a/test/appenders/test_console.rb
+++ b/test/appenders/test_console.rb
@@ -45,7 +45,12 @@ module TestAppenders
 
       appender.close
       assert appender.closed?
-      assert io.closed?
+      # We will not close the IO stream in JRuby
+      if defined?(JRUBY_VERSION)
+        refute io.closed?
+      else
+        assert io.closed?
+      end
       refute STDOUT.closed?
 
       appender.reopen
@@ -54,7 +59,11 @@ module TestAppenders
       new_io = appender.instance_variable_get(:@io)
       refute_same io, new_io
       refute new_io.closed?
-      assert io.closed?
+      if defined?(JRUBY_VERSION)
+        refute io.closed?
+      else
+        assert io.closed?
+      end
     end
   end
 
@@ -91,7 +100,12 @@ module TestAppenders
 
       appender.close
       assert appender.closed?
-      assert io.closed?
+      # We will not close the IO stream in JRuby
+      if defined?(JRUBY_VERSION)
+        refute io.closed?
+      else
+        assert io.closed?
+      end
       refute STDERR.closed?
 
       appender.reopen
@@ -100,7 +114,11 @@ module TestAppenders
       new_io = appender.instance_variable_get(:@io)
       refute_same io, new_io
       refute new_io.closed?
-      assert io.closed?
+      if defined?(JRUBY_VERSION)
+        refute io.closed?
+      else
+        assert io.closed?
+      end
     end
   end
 end

--- a/test/appenders/test_console.rb
+++ b/test/appenders/test_console.rb
@@ -22,7 +22,7 @@ module TestAppenders
       assert_equal 'stdout', appender.name
 
       io = appender.instance_variable_get(:@io)
-      refute_same STDOUT, io
+      assert_same STDOUT, io
       assert_equal STDOUT.fileno, io.fileno
 
       appender = Logging.appenders.stdout('foo')
@@ -45,25 +45,16 @@ module TestAppenders
 
       appender.close
       assert appender.closed?
-      # We will not close the IO stream in JRuby
-      if defined?(JRUBY_VERSION)
-        refute io.closed?
-      else
-        assert io.closed?
-      end
+      refute io.closed?
       refute STDOUT.closed?
 
       appender.reopen
       refute appender.closed?
 
       new_io = appender.instance_variable_get(:@io)
-      refute_same io, new_io
+      assert_same io, new_io
       refute new_io.closed?
-      if defined?(JRUBY_VERSION)
-        refute io.closed?
-      else
-        assert io.closed?
-      end
+      refute io.closed?
     end
   end
 
@@ -77,8 +68,8 @@ module TestAppenders
       assert_equal 'stderr', appender.name
 
       io = appender.instance_variable_get(:@io)
-      refute_same STDERR, io
-      assert_same STDERR.fileno, io.fileno
+      assert_same STDERR, io
+      assert_equal STDERR.fileno, io.fileno
 
       appender = Logging.appenders.stderr('foo')
       assert_equal 'foo', appender.name
@@ -100,25 +91,16 @@ module TestAppenders
 
       appender.close
       assert appender.closed?
-      # We will not close the IO stream in JRuby
-      if defined?(JRUBY_VERSION)
-        refute io.closed?
-      else
-        assert io.closed?
-      end
+      refute io.closed?
       refute STDERR.closed?
 
       appender.reopen
       refute appender.closed?
 
       new_io = appender.instance_variable_get(:@io)
-      refute_same io, new_io
+      assert_same io, new_io
       refute new_io.closed?
-      if defined?(JRUBY_VERSION)
-        refute io.closed?
-      else
-        assert io.closed?
-      end
+      refute io.closed?
     end
   end
 end


### PR DESCRIPTION
This PR includes two fixes for JRuby:

* closing copies of `STDOUT` IO streams would cause JRuby to hang - fixes #235 
* caller tracing stacks have changed with JRuby 9

The fix here is to no longer create copies of `STDOUT` and `STDERR`. Instead, we just check if the underlying IO object is one of these two and then don't bother closing them.