### PR TITLE
Add formatter= method to make the logging gem compatible with rails 7.1

### DIFF
--- a/lib/logging/rails_compat.rb
+++ b/lib/logging/rails_compat.rb
@@ -11,6 +11,9 @@ module Logging
     # A no-op implementation of the `formatter` method.
     def formatter; end
 
+    # A no-op implementation of the `formatter=` method.
+    def formatter=(_formatter); end
+
     # A no-op implementation of the +silence+ method. Setting of log levels
     # should be done during the Logging configuration. It is the author's
     # opinion that overriding the log level programmatically is a logical


### PR DESCRIPTION
Hi,

Following the convention to make the logging gem compatible with Rails versions I added empty `formatter=(_formatter)` method.

This PR is my attempt to solve the issue #245 

As I investigated Rails 7.1 introduces some changes in Rails logger and when someone upgrades their Rails they get the error:
```
NoMethodError: undefined method `formatter='
```

 [Here](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#rails-logger-now-returns-an-activesupport-broadcastlogger-instance) is the link to Rails guide with details.


@TwP could you please take a look at this PR? I would be very happy if this is proper way to solve the issue and if it would be merged 😊 

Resolves issue: #245 