### PR TITLE
Require syslog only when necessary

### DIFF
--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -6,13 +6,6 @@ require 'fileutils'
 require 'little-plugger'
 require 'multi_json'
 
-begin
-  require 'syslog'
-  HAVE_SYSLOG = true
-rescue LoadError
-  HAVE_SYSLOG = false
-end
-
 #
 #
 module Logging

--- a/lib/logging/appenders.rb
+++ b/lib/logging/appenders.rb
@@ -47,8 +47,21 @@ module Logging
     end
     # :startdoc:
 
+    # Accessor / Factory for the Syslog appender.
+    #
+    def self.syslog( *args )
+      fail ArgumentError, '::Logging::Appenders::Syslog needs a name as first argument.' if args.empty?
+      ::Logging::Appenders::Syslog.new(*args)
+    end
+
     extend self
     @appenders = Hash.new
+
+    # Load Syslog only when requested. Windows does not have syslog, and
+    # Ruby 3.4.0 will remove it from the standard library. Requiring
+    # syslog on Ruby 3.3.0 will result in an warning if the gem is not
+    # explicitly installed.
+    autoload :Syslog, Logging.libpath('logging/appenders/syslog')
   end  # Appenders
 
   require libpath('logging/appenders/buffering')
@@ -57,6 +70,5 @@ module Logging
   require libpath('logging/appenders/file')
   require libpath('logging/appenders/rolling_file')
   require libpath('logging/appenders/string_io')
-  require libpath('logging/appenders/syslog')
 end  # Logging
 

--- a/lib/logging/appenders/syslog.rb
+++ b/lib/logging/appenders/syslog.rb
@@ -1,17 +1,6 @@
-
-# only load this class if we have the syslog library
-# Windows does not have syslog
-#
-if HAVE_SYSLOG
+require 'syslog'
 
 module Logging::Appenders
-
-  # Accessor / Factory for the Syslog appender.
-  #
-  def self.syslog( *args )
-    fail ArgumentError, '::Logging::Appenders::Syslog needs a name as first argument.' if args.empty?
-    ::Logging::Appenders::Syslog.new(*args)
-  end
 
   # This class provides an Appender that can write to the UNIX syslog
   # daemon.
@@ -211,4 +200,3 @@ module Logging::Appenders
 
   end  # Syslog
 end  # Logging::Appenders
-end  # HAVE_SYSLOG

--- a/test/appenders/test_syslog.rb
+++ b/test/appenders/test_syslog.rb
@@ -1,6 +1,13 @@
 
 require File.expand_path('../setup', File.dirname(__FILE__))
 
+begin
+  require 'syslog'
+  HAVE_SYSLOG = true
+rescue LoadError
+  HAVE_SYSLOG = false
+end
+
 if HAVE_SYSLOG
 
 module TestLogging


### PR DESCRIPTION
Requiring syslog on Ruby 3.3.0 results in an warning if the gem is not explicitly installed. Suppress it by requiring syslog only when the user tries to use Logging::Appender::Syslog.